### PR TITLE
Add .editorconfig, make all whitespace consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/common.js
+++ b/common.js
@@ -23,12 +23,12 @@ function sha256(s) {
 }
 
 String.prototype.toCamelCase = function camelize() {
-    return this.toLowerCase().replace(/[-_ \/\.](.)/g, function(match, group1) {
+    return this.toLowerCase().replace(/[-_ \/\.](.)/g, function (match, group1) {
         return group1.toUpperCase();
     });
 }
 
-function recurse(object,state,callback) {
+function recurse(object, state, callback) {
     if (!state || (Object.keys(state).length === 0)) {
         state = {};
         state.path = '#';
@@ -38,19 +38,19 @@ function recurse(object,state,callback) {
         state.payload = {};
     }
     for (var key in object) {
-        var escKey = '/'+jptr.jpescape(key);
+        var escKey = '/' + jptr.jpescape(key);
         state.key = key;
         var oPath = state.path;
-        state.path = (state.path ? state.path : '#')+escKey;
-        callback(object,key,state);
+        state.path = (state.path ? state.path : '#') + escKey;
+        callback(object, key, state);
         if (typeof object[key] === 'object') {
             var newState = {};
             newState.parent = object;
             newState.path = state.path;
-            newState.depth = (state.depth ? state.depth++ : state.depth=1);
+            newState.depth = (state.depth ? state.depth++ : state.depth = 1);
             newState.pkey = key;
             newState.payload = state.payload;
-            recurse(object[key],newState,callback);
+            recurse(object[key], newState, callback);
         }
         state.path = oPath;
     }
@@ -61,51 +61,51 @@ function getVersion() {
 }
 
 function readFileAsync(filename, encoding) {
-  return new Promise(function(resolve, reject) {
-    fs.readFile(filename, encoding, function(err, data){
-      if (err)
-        reject(err);
-      else
-        resolve(data);
+    return new Promise(function (resolve, reject) {
+        fs.readFile(filename, encoding, function (err, data) {
+            if (err)
+                reject(err);
+            else
+                resolve(data);
+        });
     });
-  });
 }
 
-function resolveExternal(root,pointer,options,callback) {
+function resolveExternal(root, pointer, options, callback) {
     var u = url.parse(options.source);
     var base = options.source.split('/');
     base.pop(); // drop the actual filename
     let fragment = '';
     let fnComponents = pointer.split('#');
-    if (fnComponents.length>1) {
-        fragment = '#'+fnComponents[1];
+    if (fnComponents.length > 1) {
+        fragment = '#' + fnComponents[1];
     }
     base = base.join('/');
-    if (options.verbose) console.log((u.protocol ? 'GET ' : 'file://') + base+'/'+pointer);
+    if (options.verbose) console.log((u.protocol ? 'GET ' : 'file://') + base + '/' + pointer);
     if (u.protocol) {
-        return fetch(base+'/'+pointer)
-        .then(function(res){
-            return res.text();
-        })
-        .then(function(data){
-            try {
-                data = yaml.safeLoad(data,{json:true});
-                if (fragment) {
-                    data = resolveInternal(data,fragment);
+        return fetch(base + '/' + pointer)
+            .then(function (res) {
+                return res.text();
+            })
+            .then(function (data) {
+                try {
+                    data = yaml.safeLoad(data, { json: true });
+                    if (fragment) {
+                        data = resolveInternal(data, fragment);
+                    }
                 }
-            }
-            catch (ex) {}
-            callback(data);
-            return data;
-        });
+                catch (ex) { }
+                callback(data);
+                return data;
+            });
     }
     else {
-        return readFileAsync(base+'/'+pointer,options.encoding||'utf8');
+        return readFileAsync(base + '/' + pointer, options.encoding || 'utf8');
     }
 }
 
-function resolveInternal(root,pointer) {
-    return jptr.jptr(root,pointer)||false;
+function resolveInternal(root, pointer) {
+    return jptr.jptr(root, pointer) || false;
 }
 
 const parameterTypeProperties = [
@@ -158,17 +158,17 @@ function sanitiseAll(s) {
 
 module.exports = {
 
-    clone : clone,
-    uniqueOnly : uniqueOnly,
-    recurse : recurse,
-    sha256 : sha256,
-    getVersion : getVersion,
-    resolveExternal : resolveExternal,
-    resolveInternal : resolveInternal,
-    parameterTypeProperties : parameterTypeProperties,
-    arrayProperties : arrayProperties,
-    httpVerbs : httpVerbs,
-    sanitise : sanitise,
-    sanitiseAll : sanitiseAll
+    clone: clone,
+    uniqueOnly: uniqueOnly,
+    recurse: recurse,
+    sha256: sha256,
+    getVersion: getVersion,
+    resolveExternal: resolveExternal,
+    resolveInternal: resolveInternal,
+    parameterTypeProperties: parameterTypeProperties,
+    arrayProperties: arrayProperties,
+    httpVerbs: httpVerbs,
+    sanitise: sanitise,
+    sanitiseAll: sanitiseAll
 
 };

--- a/common.js
+++ b/common.js
@@ -17,9 +17,9 @@ function uniqueOnly(value, index, self) {
 }
 
 function sha256(s) {
-	var shasum = crypto.createHash('sha256');
-	shasum.update(s);
-	return shasum.digest('hex');
+    var shasum = crypto.createHash('sha256');
+    shasum.update(s);
+    return shasum.digest('hex');
 }
 
 String.prototype.toCamelCase = function camelize() {
@@ -29,35 +29,35 @@ String.prototype.toCamelCase = function camelize() {
 }
 
 function recurse(object,state,callback) {
-	if (!state || (Object.keys(state).length === 0)) {
-		state = {};
-		state.path = '#';
-		state.depth = 0;
-		state.pkey = '';
-		state.parent = {};
-		state.payload = {};
-	}
-	for (var key in object) {
-		var escKey = '/'+jptr.jpescape(key);
-		state.key = key;
-		var oPath = state.path;
-		state.path = (state.path ? state.path : '#')+escKey;
-		callback(object,key,state);
-		if (typeof object[key] === 'object') {
-			var newState = {};
-			newState.parent = object;
-			newState.path = state.path;
-			newState.depth = (state.depth ? state.depth++ : state.depth=1);
-			newState.pkey = key;
-			newState.payload = state.payload;
-			recurse(object[key],newState,callback);
-		}
-		state.path = oPath;
-	}
+    if (!state || (Object.keys(state).length === 0)) {
+        state = {};
+        state.path = '#';
+        state.depth = 0;
+        state.pkey = '';
+        state.parent = {};
+        state.payload = {};
+    }
+    for (var key in object) {
+        var escKey = '/'+jptr.jpescape(key);
+        state.key = key;
+        var oPath = state.path;
+        state.path = (state.path ? state.path : '#')+escKey;
+        callback(object,key,state);
+        if (typeof object[key] === 'object') {
+            var newState = {};
+            newState.parent = object;
+            newState.path = state.path;
+            newState.depth = (state.depth ? state.depth++ : state.depth=1);
+            newState.pkey = key;
+            newState.payload = state.payload;
+            recurse(object[key],newState,callback);
+        }
+        state.path = oPath;
+    }
 }
 
 function getVersion() {
-	return require('./package.json').version;
+    return require('./package.json').version;
 }
 
 function readFileAsync(filename, encoding) {
@@ -72,103 +72,103 @@ function readFileAsync(filename, encoding) {
 }
 
 function resolveExternal(root,pointer,options,callback) {
-	var u = url.parse(options.source);
-	var base = options.source.split('/');
-	base.pop(); // drop the actual filename
-	let fragment = '';
-	let fnComponents = pointer.split('#');
-	if (fnComponents.length>1) {
-		fragment = '#'+fnComponents[1];
-	}
-	base = base.join('/');
-	if (options.verbose) console.log((u.protocol ? 'GET ' : 'file://') + base+'/'+pointer);
-	if (u.protocol) {
-		return fetch(base+'/'+pointer)
-		.then(function(res){
-			return res.text();
-		})
-		.then(function(data){
-			try {
-				data = yaml.safeLoad(data,{json:true});
-				if (fragment) {
-					data = resolveInternal(data,fragment);
-				}
-			}
-			catch (ex) {}
-			callback(data);
-			return data;
-		});
-	}
-	else {
-		return readFileAsync(base+'/'+pointer,options.encoding||'utf8');
-	}
+    var u = url.parse(options.source);
+    var base = options.source.split('/');
+    base.pop(); // drop the actual filename
+    let fragment = '';
+    let fnComponents = pointer.split('#');
+    if (fnComponents.length>1) {
+        fragment = '#'+fnComponents[1];
+    }
+    base = base.join('/');
+    if (options.verbose) console.log((u.protocol ? 'GET ' : 'file://') + base+'/'+pointer);
+    if (u.protocol) {
+        return fetch(base+'/'+pointer)
+        .then(function(res){
+            return res.text();
+        })
+        .then(function(data){
+            try {
+                data = yaml.safeLoad(data,{json:true});
+                if (fragment) {
+                    data = resolveInternal(data,fragment);
+                }
+            }
+            catch (ex) {}
+            callback(data);
+            return data;
+        });
+    }
+    else {
+        return readFileAsync(base+'/'+pointer,options.encoding||'utf8');
+    }
 }
 
 function resolveInternal(root,pointer) {
-	return jptr.jptr(root,pointer)||false;
+    return jptr.jptr(root,pointer)||false;
 }
 
 const parameterTypeProperties = [
-	'format',
-	'minimum',
-	'maximum',
-	'exclusiveMinimum',
-	'exclusiveMaximum',
-	'minLength',
-	'maxLength',
-	'multipleOf',
-	'minItems',
-	'maxItems',
-	'uniqueItems',
-	'minProperties',
-	'maxProperties',
-	'additionalProperties',
-	'pattern',
-	'enum',
-	'default'
+    'format',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'minLength',
+    'maxLength',
+    'multipleOf',
+    'minItems',
+    'maxItems',
+    'uniqueItems',
+    'minProperties',
+    'maxProperties',
+    'additionalProperties',
+    'pattern',
+    'enum',
+    'default'
 ];
 
 const arrayProperties = [
-	'items',
-	'minItems',
-	'maxItems',
-	'uniqueItems'
+    'items',
+    'minItems',
+    'maxItems',
+    'uniqueItems'
 ];
 
 const httpVerbs = [
-	'get',
-	'post',
-	'put',
-	'delete',
-	'patch',
-	'head',
-	'options',
-	'trace'
+    'get',
+    'post',
+    'put',
+    'delete',
+    'patch',
+    'head',
+    'options',
+    'trace'
 ];
 
 function sanitise(s) {
-	var components = s.split('/');
-	components[0] = components[0].replace(/[^A-Za-z0-9_\-\.]+|\s+/gm, '_');
-	return components.join('/');
+    var components = s.split('/');
+    components[0] = components[0].replace(/[^A-Za-z0-9_\-\.]+|\s+/gm, '_');
+    return components.join('/');
 }
 
 function sanitiseAll(s) {
-	return sanitise(s.split('/').join('_'));
+    return sanitise(s.split('/').join('_'));
 }
 
 module.exports = {
 
-	clone : clone,
-	uniqueOnly : uniqueOnly,
-	recurse : recurse,
-	sha256 : sha256,
-	getVersion : getVersion,
-	resolveExternal : resolveExternal,
-	resolveInternal : resolveInternal,
-	parameterTypeProperties : parameterTypeProperties,
-	arrayProperties : arrayProperties,
-	httpVerbs : httpVerbs,
-	sanitise : sanitise,
-	sanitiseAll : sanitiseAll
+    clone : clone,
+    uniqueOnly : uniqueOnly,
+    recurse : recurse,
+    sha256 : sha256,
+    getVersion : getVersion,
+    resolveExternal : resolveExternal,
+    resolveInternal : resolveInternal,
+    parameterTypeProperties : parameterTypeProperties,
+    arrayProperties : arrayProperties,
+    httpVerbs : httpVerbs,
+    sanitise : sanitise,
+    sanitiseAll : sanitiseAll
 
 };

--- a/conversions/swagger2openapi/openapi.json
+++ b/conversions/swagger2openapi/openapi.json
@@ -1,1064 +1,1064 @@
 {
-  "openapi": "3.0.0",
-  "servers": [
-    {
-      "url": "http://petstore.swagger.io/v2"
-    }
-  ],
-  "x-origin": [
-    {
-      "url": "http://petstore.swagger.io/v2/swagger.json",
-      "format": "swagger",
-      "version": "2.0",
-      "converter": {
-        "url": "https://github.com/mermade/swagger2openapi",
-        "version": "2.6.3"
-      }
-    }
-  ],
-  "info": {
-    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
-    "version": "1.0.0",
-    "title": "Swagger Petstore",
-    "termsOfService": "http://swagger.io/terms/",
-    "contact": {
-      "email": "apiteam@swagger.io"
-    },
-    "license": {
-      "name": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  },
-  "tags": [
-    {
-      "name": "pet",
-      "description": "Everything about your Pets",
-      "externalDocs": {
-        "description": "Find out more",
-        "url": "http://swagger.io"
-      }
-    },
-    {
-      "name": "store",
-      "description": "Access to Petstore orders"
-    },
-    {
-      "name": "user",
-      "description": "Operations about user",
-      "externalDocs": {
-        "description": "Find out more about our store",
-        "url": "http://swagger.io"
-      }
-    }
-  ],
-  "paths": {
-    "/pet": {
-      "post": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Add a new pet to the store",
-        "description": "",
-        "operationId": "addPet",
-        "responses": {
-          "405": {
-            "description": "Invalid input"
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/Pet"
+    "openapi": "3.0.0",
+    "servers": [
+        {
+            "url": "http://petstore.swagger.io/v2"
         }
-      },
-      "put": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Update an existing pet",
-        "description": "",
-        "operationId": "updatePet",
-        "responses": {
-          "400": {
-            "description": "Invalid ID supplied"
-          },
-          "404": {
-            "description": "Pet not found"
-          },
-          "405": {
-            "description": "Validation exception"
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/Pet"
+    ],
+    "x-origin": [
+        {
+            "url": "http://petstore.swagger.io/v2/swagger.json",
+            "format": "swagger",
+            "version": "2.0",
+            "converter": {
+                "url": "https://github.com/mermade/swagger2openapi",
+                "version": "2.6.3"
+            }
         }
-      }
+    ],
+    "info": {
+        "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "email": "apiteam@swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
     },
-    "/pet/findByStatus": {
-      "get": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Finds Pets by status",
-        "description": "Multiple status values can be provided with comma separated strings",
-        "operationId": "findPetsByStatus",
-        "parameters": [
-          {
-            "name": "status",
-            "in": "query",
-            "description": "Status values that need to be considered for filter",
-            "required": true,
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "available",
-                  "pending",
-                  "sold"
+    "tags": [
+        {
+            "name": "pet",
+            "description": "Everything about your Pets",
+            "externalDocs": {
+                "description": "Find out more",
+                "url": "http://swagger.io"
+            }
+        },
+        {
+            "name": "store",
+            "description": "Access to Petstore orders"
+        },
+        {
+            "name": "user",
+            "description": "Operations about user",
+            "externalDocs": {
+                "description": "Find out more about our store",
+                "url": "http://swagger.io"
+            }
+        }
+    ],
+    "paths": {
+        "/pet": {
+            "post": {
+                "tags": [
+                    "pet"
                 ],
-                "default": "available"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Pet"
-                  }
+                "summary": "Add a new pet to the store",
+                "description": "",
+                "operationId": "addPet",
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/Pet"
                 }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Pet"
-                  }
+            },
+            "put": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Update an existing pet",
+                "description": "",
+                "operationId": "updatePet",
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/Pet"
                 }
-              }
             }
-          },
-          "400": {
-            "description": "Invalid status value"
-          }
         },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
-      }
+        "/pet/findByStatus": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma separated strings",
+                "operationId": "findPetsByStatus",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Status values that need to be considered for filter",
+                        "required": true,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "available",
+                                    "pending",
+                                    "sold"
+                                ],
+                                "default": "available"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/findByTags": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by tags",
+                "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+                "operationId": "findPetsByTags",
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tags to filter by",
+                        "required": true,
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "deprecated": true
+            }
+        },
+        "/pet/{petId}": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Find pet by ID",
+                "description": "Returns a single pet",
+                "operationId": "getPetById",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet to return",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Updates a pet in the store with form data",
+                "description": "",
+                "operationId": "updatePetWithForm",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet that needs to be updated",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "description": "Updated name of the pet",
+                                        "type": "string"
+                                    },
+                                    "status": {
+                                        "description": "Updated status of the pet",
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Deletes a pet",
+                "description": "",
+                "operationId": "deletePet",
+                "parameters": [
+                    {
+                        "name": "api_key",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "Pet id to delete",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/{petId}/uploadImage": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "uploads an image",
+                "description": "",
+                "operationId": "uploadFile",
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet to update",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/store/inventory": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Returns pet inventories by status",
+                "description": "Returns a map of status codes to quantities",
+                "operationId": "getInventory",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/store/order": {
+            "post": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Place an order for a pet",
+                "description": "",
+                "operationId": "placeOrder",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Order"
+                    }
+                },
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Order"
+                            }
+                        }
+                    },
+                    "description": "order placed for purchasing the pet",
+                    "required": true
+                }
+            }
+        },
+        "/store/order/{orderId}": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Find purchase order by ID",
+                "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+                "operationId": "getOrderById",
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete purchase order by ID",
+                "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+                "operationId": "deleteOrder",
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "description": "ID of the order that needs to be deleted",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            }
+        },
+        "/user": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Create user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "createUser",
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                },
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    },
+                    "description": "Created user object",
+                    "required": true
+                }
+            }
+        },
+        "/user/createWithArray": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithArrayInput",
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/UserArray"
+                }
+            }
+        },
+        "/user/createWithList": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithListInput",
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                },
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/UserArray"
+                }
+            }
+        },
+        "/user/login": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs user into the system",
+                "description": "",
+                "operationId": "loginUser",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The user name for login",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "description": "The password for login in clear text",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "password"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "headers": {
+                            "X-Rate-Limit": {
+                                "description": "calls per hour allowed by the user",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                }
+                            },
+                            "X-Expires-After": {
+                                "description": "date in UTC when token expires",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username/password supplied"
+                    }
+                }
+            }
+        },
+        "/user/logout": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs out current logged in user session",
+                "description": "",
+                "operationId": "logoutUser",
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/{username}": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Get user by user name",
+                "description": "",
+                "operationId": "getUserByName",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "The name that needs to be fetched. Use user1 for testing. ",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Updated user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "updateUser",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "name that need to be updated",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid user supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                },
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    },
+                    "description": "Updated user object",
+                    "required": true
+                }
+            },
+            "delete": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Delete user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "deleteUser",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "The name that needs to be deleted",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            }
+        }
     },
-    "/pet/findByTags": {
-      "get": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Finds Pets by tags",
-        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-        "operationId": "findPetsByTags",
-        "parameters": [
-          {
-            "name": "tags",
-            "in": "query",
-            "description": "Tags to filter by",
-            "required": true,
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Pet"
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Pet"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid tag value"
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ],
-        "deprecated": true
-      }
+    "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
     },
-    "/pet/{petId}": {
-      "get": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Find pet by ID",
-        "description": "Returns a single pet",
-        "operationId": "getPetById",
-        "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "description": "ID of pet to return",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Pet"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Pet"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid ID supplied"
-          },
-          "404": {
-            "description": "Pet not found"
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Updates a pet in the store with form data",
-        "description": "",
-        "operationId": "updatePetWithForm",
-        "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "description": "ID of pet that needs to be updated",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "405": {
-            "description": "Invalid input"
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
+    "components": {
+        "schemas": {
+            "Order": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "description": "Updated name of the pet",
-                    "type": "string"
-                  },
-                  "status": {
-                    "description": "Updated status of the pet",
-                    "type": "string"
-                  }
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "petId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "quantity": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "shipDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Order Status",
+                        "enum": [
+                            "placed",
+                            "approved",
+                            "delivered"
+                        ]
+                    },
+                    "complete": {
+                        "type": "boolean",
+                        "default": false
+                    }
+                },
+                "xml": {
+                    "name": "Order"
                 }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "Deletes a pet",
-        "description": "",
-        "operationId": "deletePet",
-        "parameters": [
-          {
-            "name": "api_key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "petId",
-            "in": "path",
-            "description": "Pet id to delete",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Invalid ID supplied"
-          },
-          "404": {
-            "description": "Pet not found"
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
-      }
-    },
-    "/pet/{petId}/uploadImage": {
-      "post": {
-        "tags": [
-          "pet"
-        ],
-        "summary": "uploads an image",
-        "description": "",
-        "operationId": "uploadFile",
-        "parameters": [
-          {
-            "name": "petId",
-            "in": "path",
-            "description": "ID of pet to update",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/octet-stream": {
-              "schema": {
-                "type": "string",
-                "format": "binary"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/store/inventory": {
-      "get": {
-        "tags": [
-          "store"
-        ],
-        "summary": "Returns pet inventories by status",
-        "description": "Returns a map of status codes to quantities",
-        "operationId": "getInventory",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/store/order": {
-      "post": {
-        "tags": [
-          "store"
-        ],
-        "summary": "Place an order for a pet",
-        "description": "",
-        "operationId": "placeOrder",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Order"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Order"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid Order"
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Order"
-              }
-            }
-          },
-          "description": "order placed for purchasing the pet",
-          "required": true
-        }
-      }
-    },
-    "/store/order/{orderId}": {
-      "get": {
-        "tags": [
-          "store"
-        ],
-        "summary": "Find purchase order by ID",
-        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
-        "operationId": "getOrderById",
-        "parameters": [
-          {
-            "name": "orderId",
-            "in": "path",
-            "description": "ID of pet that needs to be fetched",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1,
-              "maximum": 10
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/Order"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Order"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid ID supplied"
-          },
-          "404": {
-            "description": "Order not found"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "store"
-        ],
-        "summary": "Delete purchase order by ID",
-        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
-        "operationId": "deleteOrder",
-        "parameters": [
-          {
-            "name": "orderId",
-            "in": "path",
-            "description": "ID of the order that needs to be deleted",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Invalid ID supplied"
-          },
-          "404": {
-            "description": "Order not found"
-          }
-        }
-      }
-    },
-    "/user": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Create user",
-        "description": "This can only be done by the logged in user.",
-        "operationId": "createUser",
-        "responses": {
-          "default": {
-            "description": "successful operation"
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/User"
-              }
-            }
-          },
-          "description": "Created user object",
-          "required": true
-        }
-      }
-    },
-    "/user/createWithArray": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Creates list of users with given input array",
-        "description": "",
-        "operationId": "createUsersWithArrayInput",
-        "responses": {
-          "default": {
-            "description": "successful operation"
-          }
-        },
-        "requestBody": {
-          "$ref": "#/components/requestBodies/UserArray"
-        }
-      }
-    },
-    "/user/createWithList": {
-      "post": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Creates list of users with given input array",
-        "description": "",
-        "operationId": "createUsersWithListInput",
-        "responses": {
-          "default": {
-            "description": "successful operation"
-          }
-        },
-        "requestBody": {
-          "$ref": "#/components/requestBodies/UserArray"
-        }
-      }
-    },
-    "/user/login": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Logs user into the system",
-        "description": "",
-        "operationId": "loginUser",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "query",
-            "description": "The user name for login",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "password",
-            "in": "query",
-            "description": "The password for login in clear text",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "password"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "headers": {
-              "X-Rate-Limit": {
-                "description": "calls per hour allowed by the user",
-                "schema": {
-                  "type": "integer",
-                  "format": "int32"
-                }
-              },
-              "X-Expires-After": {
-                "description": "date in UTC when token expires",
-                "schema": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
             },
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "type": "string"
+            "Category": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Category"
                 }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "string"
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "userStatus": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "User Status"
+                    }
+                },
+                "xml": {
+                    "name": "User"
                 }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid username/password supplied"
-          }
-        }
-      }
-    },
-    "/user/logout": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Logs out current logged in user session",
-        "description": "",
-        "operationId": "logoutUser",
-        "responses": {
-          "default": {
-            "description": "successful operation"
-          }
-        }
-      }
-    },
-    "/user/{username}": {
-      "get": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Get user by user name",
-        "description": "",
-        "operationId": "getUserByName",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "description": "The name that needs to be fetched. Use user1 for testing. ",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
+            },
+            "Tag": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "Tag"
                 }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
+            },
+            "Pet": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "photoUrls"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "category": {
+                        "$ref": "#/components/schemas/Category"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "doggie"
+                    },
+                    "photoUrls": {
+                        "type": "array",
+                        "xml": {
+                            "name": "photoUrl",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "xml": {
+                            "name": "tag",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/components/schemas/Tag"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": [
+                            "available",
+                            "pending",
+                            "sold"
+                        ]
+                    }
+                },
+                "xml": {
+                    "name": "Pet"
                 }
-              }
+            },
+            "ApiResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
             }
-          },
-          "400": {
-            "description": "Invalid username supplied"
-          },
-          "404": {
-            "description": "User not found"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Updated user",
-        "description": "This can only be done by the logged in user.",
-        "operationId": "updateUser",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "description": "name that need to be updated",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Invalid user supplied"
-          },
-          "404": {
-            "description": "User not found"
-          }
         },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/User"
-              }
+        "requestBodies": {
+            "Pet": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    },
+                    "application/xml": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                },
+                "description": "Pet object that needs to be added to the store",
+                "required": true
+            },
+            "UserArray": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    }
+                },
+                "description": "List of user object",
+                "required": true
             }
-          },
-          "description": "Updated user object",
-          "required": true
-        }
-      },
-      "delete": {
-        "tags": [
-          "user"
-        ],
-        "summary": "Delete user",
-        "description": "This can only be done by the logged in user.",
-        "operationId": "deleteUser",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "description": "The name that needs to be deleted",
-            "required": true,
-            "schema": {
-              "type": "string"
+        },
+        "securitySchemes": {
+            "petstore_auth": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                        "scopes": {
+                            "write:pets": "modify pets in your account",
+                            "read:pets": "read your pets"
+                        }
+                    }
+                }
+            },
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
             }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Invalid username supplied"
-          },
-          "404": {
-            "description": "User not found"
-          }
         }
-      }
     }
-  },
-  "externalDocs": {
-    "description": "Find out more about Swagger",
-    "url": "http://swagger.io"
-  },
-  "components": {
-    "schemas": {
-      "Order": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "petId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "quantity": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "shipDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "description": "Order Status",
-            "enum": [
-              "placed",
-              "approved",
-              "delivered"
-            ]
-          },
-          "complete": {
-            "type": "boolean",
-            "default": false
-          }
-        },
-        "xml": {
-          "name": "Order"
-        }
-      },
-      "Category": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "xml": {
-          "name": "Category"
-        }
-      },
-      "User": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "username": {
-            "type": "string"
-          },
-          "firstName": {
-            "type": "string"
-          },
-          "lastName": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "password": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          },
-          "userStatus": {
-            "type": "integer",
-            "format": "int32",
-            "description": "User Status"
-          }
-        },
-        "xml": {
-          "name": "User"
-        }
-      },
-      "Tag": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "xml": {
-          "name": "Tag"
-        }
-      },
-      "Pet": {
-        "type": "object",
-        "required": [
-          "name",
-          "photoUrls"
-        ],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "category": {
-            "$ref": "#/components/schemas/Category"
-          },
-          "name": {
-            "type": "string",
-            "example": "doggie"
-          },
-          "photoUrls": {
-            "type": "array",
-            "xml": {
-              "name": "photoUrl",
-              "wrapped": true
-            },
-            "items": {
-              "type": "string"
-            }
-          },
-          "tags": {
-            "type": "array",
-            "xml": {
-              "name": "tag",
-              "wrapped": true
-            },
-            "items": {
-              "$ref": "#/components/schemas/Tag"
-            }
-          },
-          "status": {
-            "type": "string",
-            "description": "pet status in the store",
-            "enum": [
-              "available",
-              "pending",
-              "sold"
-            ]
-          }
-        },
-        "xml": {
-          "name": "Pet"
-        }
-      },
-      "ApiResponse": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "type": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "requestBodies": {
-      "Pet": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Pet"
-            }
-          },
-          "application/xml": {
-            "schema": {
-              "$ref": "#/components/schemas/Pet"
-            }
-          }
-        },
-        "description": "Pet object that needs to be added to the store",
-        "required": true
-      },
-      "UserArray": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/User"
-              }
-            }
-          }
-        },
-        "description": "List of user object",
-        "required": true
-      }
-    },
-    "securitySchemes": {
-      "petstore_auth": {
-        "type": "oauth2",
-        "flows": {
-          "implicit": {
-            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-            "scopes": {
-              "write:pets": "modify pets in your account",
-              "read:pets": "read your pets"
-            }
-          }
-        }
-      },
-      "api_key": {
-        "type": "apiKey",
-        "name": "api_key",
-        "in": "header"
-      }
-    }
-  }
 }

--- a/conversions/swagger2openapi/petstore.json
+++ b/conversions/swagger2openapi/petstore.json
@@ -1,853 +1,1036 @@
 {
-	"swagger" : "2.0",
-	"info" : {
-		"description" : "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
-		"version" : "1.0.0",
-		"title" : "Swagger Petstore",
-		"termsOfService" : "http://swagger.io/terms/",
-		"contact" : {
-			"email" : "apiteam@swagger.io"
-		},
-		"license" : {
-			"name" : "Apache 2.0",
-			"url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
-		}
-	},
-	"host" : "petstore.swagger.io",
-	"basePath" : "/v2",
-	"tags" : [{
-			"name" : "pet",
-			"description" : "Everything about your Pets",
-			"externalDocs" : {
-				"description" : "Find out more",
-				"url" : "http://swagger.io"
-			}
-		}, {
-			"name" : "store",
-			"description" : "Access to Petstore orders"
-		}, {
-			"name" : "user",
-			"description" : "Operations about user",
-			"externalDocs" : {
-				"description" : "Find out more about our store",
-				"url" : "http://swagger.io"
-			}
-		}
-	],
-	"schemes" : ["http"],
-	"paths" : {
-		"/pet" : {
-			"post" : {
-				"tags" : ["pet"],
-				"summary" : "Add a new pet to the store",
-				"description" : "",
-				"operationId" : "addPet",
-				"consumes" : ["application/json", "application/xml"],
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "Pet object that needs to be added to the store",
-						"required" : true,
-						"schema" : {
-							"$ref" : "#/definitions/Pet"
-						}
-					}
-				],
-				"responses" : {
-					"405" : {
-						"description" : "Invalid input"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			},
-			"put" : {
-				"tags" : ["pet"],
-				"summary" : "Update an existing pet",
-				"description" : "",
-				"operationId" : "updatePet",
-				"consumes" : ["application/json", "application/xml"],
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "Pet object that needs to be added to the store",
-						"required" : true,
-						"schema" : {
-							"$ref" : "#/definitions/Pet"
-						}
-					}
-				],
-				"responses" : {
-					"400" : {
-						"description" : "Invalid ID supplied"
-					},
-					"404" : {
-						"description" : "Pet not found"
-					},
-					"405" : {
-						"description" : "Validation exception"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			}
-		},
-		"/pet/findByStatus" : {
-			"get" : {
-				"tags" : ["pet"],
-				"summary" : "Finds Pets by status",
-				"description" : "Multiple status values can be provided with comma separated strings",
-				"operationId" : "findPetsByStatus",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "status",
-						"in" : "query",
-						"description" : "Status values that need to be considered for filter",
-						"required" : true,
-						"type" : "array",
-						"items" : {
-							"type" : "string",
-							"enum" : ["available", "pending", "sold"],
-							"default" : "available"
-						},
-						"collectionFormat" : "multi"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"type" : "array",
-							"items" : {
-								"$ref" : "#/definitions/Pet"
-							}
-						}
-					},
-					"400" : {
-						"description" : "Invalid status value"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			}
-		},
-		"/pet/findByTags" : {
-			"get" : {
-				"tags" : ["pet"],
-				"summary" : "Finds Pets by tags",
-				"description" : "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-				"operationId" : "findPetsByTags",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "tags",
-						"in" : "query",
-						"description" : "Tags to filter by",
-						"required" : true,
-						"type" : "array",
-						"items" : {
-							"type" : "string"
-						},
-						"collectionFormat" : "multi"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"type" : "array",
-							"items" : {
-								"$ref" : "#/definitions/Pet"
-							}
-						}
-					},
-					"400" : {
-						"description" : "Invalid tag value"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				],
-				"deprecated" : true
-			}
-		},
-		"/pet/{petId}" : {
-			"get" : {
-				"tags" : ["pet"],
-				"summary" : "Find pet by ID",
-				"description" : "Returns a single pet",
-				"operationId" : "getPetById",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "petId",
-						"in" : "path",
-						"description" : "ID of pet to return",
-						"required" : true,
-						"type" : "integer",
-						"format" : "int64"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"$ref" : "#/definitions/Pet"
-						}
-					},
-					"400" : {
-						"description" : "Invalid ID supplied"
-					},
-					"404" : {
-						"description" : "Pet not found"
-					}
-				},
-				"security" : [{
-						"api_key" : []
-					}
-				]
-			},
-			"post" : {
-				"tags" : ["pet"],
-				"summary" : "Updates a pet in the store with form data",
-				"description" : "",
-				"operationId" : "updatePetWithForm",
-				"consumes" : ["application/x-www-form-urlencoded"],
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "petId",
-						"in" : "path",
-						"description" : "ID of pet that needs to be updated",
-						"required" : true,
-						"type" : "integer",
-						"format" : "int64"
-					}, {
-						"name" : "name",
-						"in" : "formData",
-						"description" : "Updated name of the pet",
-						"required" : false,
-						"type" : "string"
-					}, {
-						"name" : "status",
-						"in" : "formData",
-						"description" : "Updated status of the pet",
-						"required" : false,
-						"type" : "string"
-					}
-				],
-				"responses" : {
-					"405" : {
-						"description" : "Invalid input"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			},
-			"delete" : {
-				"tags" : ["pet"],
-				"summary" : "Deletes a pet",
-				"description" : "",
-				"operationId" : "deletePet",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "api_key",
-						"in" : "header",
-						"required" : false,
-						"type" : "string"
-					}, {
-						"name" : "petId",
-						"in" : "path",
-						"description" : "Pet id to delete",
-						"required" : true,
-						"type" : "integer",
-						"format" : "int64"
-					}
-				],
-				"responses" : {
-					"400" : {
-						"description" : "Invalid ID supplied"
-					},
-					"404" : {
-						"description" : "Pet not found"
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			}
-		},
-		"/pet/{petId}/uploadImage" : {
-			"post" : {
-				"tags" : ["pet"],
-				"summary" : "uploads an image",
-				"description" : "",
-				"operationId" : "uploadFile",
-				"consumes" : ["multipart/form-data"],
-				"produces" : ["application/json"],
-				"parameters" : [{
-						"name" : "petId",
-						"in" : "path",
-						"description" : "ID of pet to update",
-						"required" : true,
-						"type" : "integer",
-						"format" : "int64"
-					}, {
-						"name" : "additionalMetadata",
-						"in" : "formData",
-						"description" : "Additional data to pass to server",
-						"required" : false,
-						"type" : "string"
-					}, {
-						"name" : "file",
-						"in" : "formData",
-						"description" : "file to upload",
-						"required" : false,
-						"type" : "file"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"$ref" : "#/definitions/ApiResponse"
-						}
-					}
-				},
-				"security" : [{
-						"petstore_auth" : ["write:pets", "read:pets"]
-					}
-				]
-			}
-		},
-		"/store/inventory" : {
-			"get" : {
-				"tags" : ["store"],
-				"summary" : "Returns pet inventories by status",
-				"description" : "Returns a map of status codes to quantities",
-				"operationId" : "getInventory",
-				"produces" : ["application/json"],
-				"parameters" : [],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"type" : "object",
-							"additionalProperties" : {
-								"type" : "integer",
-								"format" : "int32"
-							}
-						}
-					}
-				},
-				"security" : [{
-						"api_key" : []
-					}
-				]
-			}
-		},
-		"/store/order" : {
-			"post" : {
-				"tags" : ["store"],
-				"summary" : "Place an order for a pet",
-				"description" : "",
-				"operationId" : "placeOrder",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "order placed for purchasing the pet",
-						"required" : true,
-						"schema" : {
-							"$ref" : "#/definitions/Order"
-						}
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"$ref" : "#/definitions/Order"
-						}
-					},
-					"400" : {
-						"description" : "Invalid Order"
-					}
-				}
-			}
-		},
-		"/store/order/{orderId}" : {
-			"get" : {
-				"tags" : ["store"],
-				"summary" : "Find purchase order by ID",
-				"description" : "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
-				"operationId" : "getOrderById",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "orderId",
-						"in" : "path",
-						"description" : "ID of pet that needs to be fetched",
-						"required" : true,
-						"type" : "integer",
-						"maximum" : 10.0,
-						"minimum" : 1.0,
-						"format" : "int64"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"$ref" : "#/definitions/Order"
-						}
-					},
-					"400" : {
-						"description" : "Invalid ID supplied"
-					},
-					"404" : {
-						"description" : "Order not found"
-					}
-				}
-			},
-			"delete" : {
-				"tags" : ["store"],
-				"summary" : "Delete purchase order by ID",
-				"description" : "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
-				"operationId" : "deleteOrder",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "orderId",
-						"in" : "path",
-						"description" : "ID of the order that needs to be deleted",
-						"required" : true,
-						"type" : "integer",
-						"minimum" : 1.0,
-						"format" : "int64"
-					}
-				],
-				"responses" : {
-					"400" : {
-						"description" : "Invalid ID supplied"
-					},
-					"404" : {
-						"description" : "Order not found"
-					}
-				}
-			}
-		},
-		"/user" : {
-			"post" : {
-				"tags" : ["user"],
-				"summary" : "Create user",
-				"description" : "This can only be done by the logged in user.",
-				"operationId" : "createUser",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "Created user object",
-						"required" : true,
-						"schema" : {
-							"$ref" : "#/definitions/User"
-						}
-					}
-				],
-				"responses" : {
-					"default" : {
-						"description" : "successful operation"
-					}
-				}
-			}
-		},
-		"/user/createWithArray" : {
-			"post" : {
-				"tags" : ["user"],
-				"summary" : "Creates list of users with given input array",
-				"description" : "",
-				"operationId" : "createUsersWithArrayInput",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "List of user object",
-						"required" : true,
-						"schema" : {
-							"type" : "array",
-							"items" : {
-								"$ref" : "#/definitions/User"
-							}
-						}
-					}
-				],
-				"responses" : {
-					"default" : {
-						"description" : "successful operation"
-					}
-				}
-			}
-		},
-		"/user/createWithList" : {
-			"post" : {
-				"tags" : ["user"],
-				"summary" : "Creates list of users with given input array",
-				"description" : "",
-				"operationId" : "createUsersWithListInput",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"in" : "body",
-						"name" : "body",
-						"description" : "List of user object",
-						"required" : true,
-						"schema" : {
-							"type" : "array",
-							"items" : {
-								"$ref" : "#/definitions/User"
-							}
-						}
-					}
-				],
-				"responses" : {
-					"default" : {
-						"description" : "successful operation"
-					}
-				}
-			}
-		},
-		"/user/login" : {
-			"get" : {
-				"tags" : ["user"],
-				"summary" : "Logs user into the system",
-				"description" : "",
-				"operationId" : "loginUser",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "username",
-						"in" : "query",
-						"description" : "The user name for login",
-						"required" : true,
-						"type" : "string"
-					}, {
-						"name" : "password",
-						"in" : "query",
-						"description" : "The password for login in clear text",
-						"required" : true,
-						"type" : "string",
-						"format": "password"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"type" : "string"
-						},
-						"headers" : {
-							"X-Rate-Limit" : {
-								"type" : "integer",
-								"format" : "int32",
-								"description" : "calls per hour allowed by the user"
-							},
-							"X-Expires-After" : {
-								"type" : "string",
-								"format" : "date-time",
-								"description" : "date in UTC when token expires"
-							}
-						}
-					},
-					"400" : {
-						"description" : "Invalid username/password supplied"
-					}
-				}
-			}
-		},
-		"/user/logout" : {
-			"get" : {
-				"tags" : ["user"],
-				"summary" : "Logs out current logged in user session",
-				"description" : "",
-				"operationId" : "logoutUser",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [],
-				"responses" : {
-					"default" : {
-						"description" : "successful operation"
-					}
-				}
-			}
-		},
-		"/user/{username}" : {
-			"get" : {
-				"tags" : ["user"],
-				"summary" : "Get user by user name",
-				"description" : "",
-				"operationId" : "getUserByName",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "username",
-						"in" : "path",
-						"description" : "The name that needs to be fetched. Use user1 for testing. ",
-						"required" : true,
-						"type" : "string"
-					}
-				],
-				"responses" : {
-					"200" : {
-						"description" : "successful operation",
-						"schema" : {
-							"$ref" : "#/definitions/User"
-						}
-					},
-					"400" : {
-						"description" : "Invalid username supplied"
-					},
-					"404" : {
-						"description" : "User not found"
-					}
-				}
-			},
-			"put" : {
-				"tags" : ["user"],
-				"summary" : "Updated user",
-				"description" : "This can only be done by the logged in user.",
-				"operationId" : "updateUser",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "username",
-						"in" : "path",
-						"description" : "name that need to be updated",
-						"required" : true,
-						"type" : "string"
-					}, {
-						"in" : "body",
-						"name" : "body",
-						"description" : "Updated user object",
-						"required" : true,
-						"schema" : {
-							"$ref" : "#/definitions/User"
-						}
-					}
-				],
-				"responses" : {
-					"400" : {
-						"description" : "Invalid user supplied"
-					},
-					"404" : {
-						"description" : "User not found"
-					}
-				}
-			},
-			"delete" : {
-				"tags" : ["user"],
-				"summary" : "Delete user",
-				"description" : "This can only be done by the logged in user.",
-				"operationId" : "deleteUser",
-				"produces" : ["application/xml", "application/json"],
-				"parameters" : [{
-						"name" : "username",
-						"in" : "path",
-						"description" : "The name that needs to be deleted",
-						"required" : true,
-						"type" : "string"
-					}
-				],
-				"responses" : {
-					"400" : {
-						"description" : "Invalid username supplied"
-					},
-					"404" : {
-						"description" : "User not found"
-					}
-				}
-			}
-		}
-	},
-	"securityDefinitions" : {
-		"petstore_auth" : {
-			"type" : "oauth2",
-			"authorizationUrl" : "http://petstore.swagger.io/oauth/dialog",
-			"flow" : "implicit",
-			"scopes" : {
-				"write:pets" : "modify pets in your account",
-				"read:pets" : "read your pets"
-			}
-		},
-		"api_key" : {
-			"type" : "apiKey",
-			"name" : "api_key",
-			"in" : "header"
-		}
-	},
-	"definitions" : {
-		"Order" : {
-			"type" : "object",
-			"properties" : {
-				"id" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"petId" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"quantity" : {
-					"type" : "integer",
-					"format" : "int32"
-				},
-				"shipDate" : {
-					"type" : "string",
-					"format" : "date-time"
-				},
-				"status" : {
-					"type" : "string",
-					"description" : "Order Status",
-					"enum" : ["placed", "approved", "delivered"]
-				},
-				"complete" : {
-					"type" : "boolean",
-					"default" : false
-				}
-			},
-			"xml" : {
-				"name" : "Order"
-			}
-		},
-		"Category" : {
-			"type" : "object",
-			"properties" : {
-				"id" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"name" : {
-					"type" : "string"
-				}
-			},
-			"xml" : {
-				"name" : "Category"
-			}
-		},
-		"User" : {
-			"type" : "object",
-			"properties" : {
-				"id" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"username" : {
-					"type" : "string"
-				},
-				"firstName" : {
-					"type" : "string"
-				},
-				"lastName" : {
-					"type" : "string"
-				},
-				"email" : {
-					"type" : "string"
-				},
-				"password" : {
-					"type" : "string"
-				},
-				"phone" : {
-					"type" : "string"
-				},
-				"userStatus" : {
-					"type" : "integer",
-					"format" : "int32",
-					"description" : "User Status"
-				}
-			},
-			"xml" : {
-				"name" : "User"
-			}
-		},
-		"Tag" : {
-			"type" : "object",
-			"properties" : {
-				"id" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"name" : {
-					"type" : "string"
-				}
-			},
-			"xml" : {
-				"name" : "Tag"
-			}
-		},
-		"Pet" : {
-			"type" : "object",
-			"required" : ["name", "photoUrls"],
-			"properties" : {
-				"id" : {
-					"type" : "integer",
-					"format" : "int64"
-				},
-				"category" : {
-					"$ref" : "#/definitions/Category"
-				},
-				"name" : {
-					"type" : "string",
-					"example" : "doggie"
-				},
-				"photoUrls" : {
-					"type" : "array",
-					"xml" : {
-						"name" : "photoUrl",
-						"wrapped" : true
-					},
-					"items" : {
-						"type" : "string"
-					}
-				},
-				"tags" : {
-					"type" : "array",
-					"xml" : {
-						"name" : "tag",
-						"wrapped" : true
-					},
-					"items" : {
-						"$ref" : "#/definitions/Tag"
-					}
-				},
-				"status" : {
-					"type" : "string",
-					"description" : "pet status in the store",
-					"enum" : ["available", "pending", "sold"]
-				}
-			},
-			"xml" : {
-				"name" : "Pet"
-			}
-		},
-		"ApiResponse" : {
-			"type" : "object",
-			"properties" : {
-				"code" : {
-					"type" : "integer",
-					"format" : "int32"
-				},
-				"type" : {
-					"type" : "string"
-				},
-				"message" : {
-					"type" : "string"
-				}
-			}
-		}
-	},
-	"externalDocs" : {
-		"description" : "Find out more about Swagger",
-		"url" : "http://swagger.io"
-	}
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "email": "apiteam@swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/v2",
+    "tags": [
+        {
+            "name": "pet",
+            "description": "Everything about your Pets",
+            "externalDocs": {
+                "description": "Find out more",
+                "url": "http://swagger.io"
+            }
+        },
+        {
+            "name": "store",
+            "description": "Access to Petstore orders"
+        },
+        {
+            "name": "user",
+            "description": "Operations about user",
+            "externalDocs": {
+                "description": "Find out more about our store",
+                "url": "http://swagger.io"
+            }
+        }
+    ],
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/pet": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Add a new pet to the store",
+                "description": "",
+                "operationId": "addPet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Update an existing pet",
+                "description": "",
+                "operationId": "updatePet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/findByStatus": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma separated strings",
+                "operationId": "findPetsByStatus",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Status values that need to be considered for filter",
+                        "required": true,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "available",
+                                "pending",
+                                "sold"
+                            ],
+                            "default": "available"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/findByTags": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by tags",
+                "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+                "operationId": "findPetsByTags",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tags to filter by",
+                        "required": true,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ],
+                "deprecated": true
+            }
+        },
+        "/pet/{petId}": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Find pet by ID",
+                "description": "Returns a single pet",
+                "operationId": "getPetById",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet to return",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Updates a pet in the store with form data",
+                "description": "",
+                "operationId": "updatePetWithForm",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet that needs to be updated",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    {
+                        "name": "name",
+                        "in": "formData",
+                        "description": "Updated name of the pet",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "status",
+                        "in": "formData",
+                        "description": "Updated status of the pet",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Deletes a pet",
+                "description": "",
+                "operationId": "deletePet",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "api_key",
+                        "in": "header",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "Pet id to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pet/{petId}/uploadImage": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "uploads an image",
+                "description": "",
+                "operationId": "uploadFile",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "description": "ID of pet to update",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    {
+                        "name": "additionalMetadata",
+                        "in": "formData",
+                        "description": "Additional data to pass to server",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "name": "file",
+                        "in": "formData",
+                        "description": "file to upload",
+                        "required": false,
+                        "type": "file"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ApiResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/store/inventory": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Returns pet inventories by status",
+                "description": "Returns a map of status codes to quantities",
+                "operationId": "getInventory",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "integer",
+                                "format": "int32"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/store/order": {
+            "post": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Place an order for a pet",
+                "description": "",
+                "operationId": "placeOrder",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "order placed for purchasing the pet",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Order"
+                    }
+                }
+            }
+        },
+        "/store/order/{orderId}": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Find purchase order by ID",
+                "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+                "operationId": "getOrderById",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "type": "integer",
+                        "maximum": 10.0,
+                        "minimum": 1.0,
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete purchase order by ID",
+                "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+                "operationId": "deleteOrder",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "description": "ID of the order that needs to be deleted",
+                        "required": true,
+                        "type": "integer",
+                        "minimum": 1.0,
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            }
+        },
+        "/user": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Create user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "createUser",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Created user object",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/createWithArray": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithArrayInput",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "List of user object",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/createWithList": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithListInput",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "List of user object",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/login": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs user into the system",
+                "description": "",
+                "operationId": "loginUser",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The user name for login",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "description": "The password for login in clear text",
+                        "required": true,
+                        "type": "string",
+                        "format": "password"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "headers": {
+                            "X-Rate-Limit": {
+                                "type": "integer",
+                                "format": "int32",
+                                "description": "calls per hour allowed by the user"
+                            },
+                            "X-Expires-After": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "date in UTC when token expires"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username/password supplied"
+                    }
+                }
+            }
+        },
+        "/user/logout": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs out current logged in user session",
+                "description": "",
+                "operationId": "logoutUser",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/{username}": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Get user by user name",
+                "description": "",
+                "operationId": "getUserByName",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "The name that needs to be fetched. Use user1 for testing. ",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Updated user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "updateUser",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "name that need to be updated",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Updated user object",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid user supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Delete user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "deleteUser",
+                "produces": [
+                    "application/xml",
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "The name that needs to be deleted",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "petstore_auth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "flow": "implicit",
+            "scopes": {
+                "write:pets": "modify pets in your account",
+                "read:pets": "read your pets"
+            }
+        },
+        "api_key": {
+            "type": "apiKey",
+            "name": "api_key",
+            "in": "header"
+        }
+    },
+    "definitions": {
+        "Order": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status",
+                    "enum": [
+                        "placed",
+                        "approved",
+                        "delivered"
+                    ]
+                },
+                "complete": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "xml": {
+                "name": "Order"
+            }
+        },
+        "Category": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "Category"
+            }
+        },
+        "User": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "userStatus": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "User Status"
+                }
+            },
+            "xml": {
+                "name": "User"
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "xml": {
+                "name": "Tag"
+            }
+        },
+        "Pet": {
+            "type": "object",
+            "required": [
+                "name",
+                "photoUrls"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "category": {
+                    "$ref": "#/definitions/Category"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "doggie"
+                },
+                "photoUrls": {
+                    "type": "array",
+                    "xml": {
+                        "name": "photoUrl",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "xml": {
+                        "name": "tag",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": [
+                        "available",
+                        "pending",
+                        "sold"
+                    ]
+                }
+            },
+            "xml": {
+                "name": "Pet"
+            }
+        },
+        "ApiResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+    }
 }

--- a/index.js
+++ b/index.js
@@ -20,1153 +20,1153 @@ const targetVersion = '3.0.0';
 var componentNames; // initialised in main
 
 function throwError(message,options) {
-	var err = new Error(message);
-	err.options = options;
-	throw err;
+    var err = new Error(message);
+    err.options = options;
+    throw err;
 }
 
 function fixupSchema(obj,key,state){
-	if (state.payload.targetted && (key == 'type') && (Array.isArray(obj[key]))) {
-		if (obj[key].length < 2) {
-			obj[key] = (obj[key].length ? obj[key][0] : 'string');
-		}
-		else {
-			obj.oneOf = [];
-			for (let type of obj[key]) {
-				var schema = {};
-				if (type === 'null') {
-					obj.nullable = true;
-				}
-				else {
-					schema.type = type;
-				}
-				if (type == 'array') {
-					for (let prop of common.arrayProperties) {
-						if (typeof obj[prop] !== 'undefined') {
-							schema[prop] = obj[prop];
-							delete obj[prop];
-						}
-					}
-				}
-				if (schema.type) obj.oneOf.push(schema);
-			}
-			if (obj.oneOf.length != 1) {
-				delete obj[key];
-			}
-			else {
-				obj[key] = obj.oneOf[0].type;
-				delete obj.oneOf;
-			}
+    if (state.payload.targetted && (key == 'type') && (Array.isArray(obj[key]))) {
+        if (obj[key].length < 2) {
+            obj[key] = (obj[key].length ? obj[key][0] : 'string');
+        }
+        else {
+            obj.oneOf = [];
+            for (let type of obj[key]) {
+                var schema = {};
+                if (type === 'null') {
+                    obj.nullable = true;
+                }
+                else {
+                    schema.type = type;
+                }
+                if (type == 'array') {
+                    for (let prop of common.arrayProperties) {
+                        if (typeof obj[prop] !== 'undefined') {
+                            schema[prop] = obj[prop];
+                            delete obj[prop];
+                        }
+                    }
+                }
+                if (schema.type) obj.oneOf.push(schema);
+            }
+            if (obj.oneOf.length != 1) {
+                delete obj[key];
+            }
+            else {
+                obj[key] = obj.oneOf[0].type;
+                delete obj.oneOf;
+            }
 
-		}
-	}
-	if ((key == 'required') && (typeof obj[key] === 'boolean') && state.payload.targetted) {
-		delete obj[key]; // TODO check we're at the right level(s) if poss.
-	}
-	if (state.payload.targetted && (key == 'properties') && (typeof obj[key] === 'object')) {
-		if ((state.pkey !== 'properties') && (typeof obj.type === 'undefined')) {
-			obj.type = 'object';
-		}
-	}
-	if (state.payload.targetted && (key == 'discriminator') && (typeof obj[key] === 'string')) {
-		obj[key] = {propertyName:obj[key]};
-	}
-	if (key == 'x-anyOf') {
-		obj.anyOf = obj[key];
-		delete obj[key];
-	}
-	if (key == 'x-oneOf') {
-		obj.oneOf = obj[key];
-		delete obj[key];
-	}
-	if (key == 'x-not') {
-		obj.not = obj[key];
-		delete obj[key];
-	}
-	if ((key == 'type') && (obj[key] == 'null')) {
-		delete obj[key];
-		obj.nullable = true;
-	}
-	if (state.payload.targetted && (key == 'x-nullable') && (typeof obj[key] === 'boolean')) {
-		obj.nullable = obj[key];
-		delete obj[key];
-	}
-	if (state.payload.targetted && (key == 'items') && Array.isArray(obj[key])) {
-		if (obj[key].length == 0) {
-			obj[key] = {};
-		}
-		else if (obj[key].length == 1) {
-			obj[key] = obj[key][0];
-		}
-		else {
-			obj[key] = {
-				anyOf: obj[key]
-			};
-		}
-	}
-	if ((key == 'x-required') && Array.isArray(obj[key])) {
-		if (!obj.required) {
-			obj.required = [];
-		}
-		obj.required = obj.required.concat(obj[key]);
-		delete obj[key];
-	}
-	if ((key == '$ref') && (typeof obj[key] === 'string')) {
-		if (obj[key].startsWith('#/definitions/')) {
-			//only the first part of a schema component name must be sanitised
-			let keys = obj[key].replace('#/definitions/','').split('/');
-			keys[0] = componentNames.schemas[keys[0]]; //lookup
-			obj[key] = '#/components/schemas/'+keys.join('/');
-		}
-		if (obj[key].startsWith('#/parameters/')) {
-			// for extensions like Apigee's x-templates
-			obj[key] = '#/components/parameters/'+common.sanitise(obj[key].replace('#/parameters/',''));
-		}
-		if (obj[key].startsWith('#/responses/')) {
-			// for extensions like Apigee's x-templates
-			obj[key] = '#/components/responses/'+common.sanitise(obj[key].replace('#/responses/',''));
-		}
-		Object.keys(obj).forEach(function(k){
-			if (k !== '$ref') delete obj[k];
-		});
-	}
-	if ((key == 'x-ms-odata') && (typeof obj[key] === 'string')) {
-		let keys = obj[key].replace('#/definitions/','').split('/');
-		keys[0] = componentNames.schemas[keys[0]]; //lookup
-		obj[key] = '#/components/schemas/'+keys.join('/');
-	}
+        }
+    }
+    if ((key == 'required') && (typeof obj[key] === 'boolean') && state.payload.targetted) {
+        delete obj[key]; // TODO check we're at the right level(s) if poss.
+    }
+    if (state.payload.targetted && (key == 'properties') && (typeof obj[key] === 'object')) {
+        if ((state.pkey !== 'properties') && (typeof obj.type === 'undefined')) {
+            obj.type = 'object';
+        }
+    }
+    if (state.payload.targetted && (key == 'discriminator') && (typeof obj[key] === 'string')) {
+        obj[key] = {propertyName:obj[key]};
+    }
+    if (key == 'x-anyOf') {
+        obj.anyOf = obj[key];
+        delete obj[key];
+    }
+    if (key == 'x-oneOf') {
+        obj.oneOf = obj[key];
+        delete obj[key];
+    }
+    if (key == 'x-not') {
+        obj.not = obj[key];
+        delete obj[key];
+    }
+    if ((key == 'type') && (obj[key] == 'null')) {
+        delete obj[key];
+        obj.nullable = true;
+    }
+    if (state.payload.targetted && (key == 'x-nullable') && (typeof obj[key] === 'boolean')) {
+        obj.nullable = obj[key];
+        delete obj[key];
+    }
+    if (state.payload.targetted && (key == 'items') && Array.isArray(obj[key])) {
+        if (obj[key].length == 0) {
+            obj[key] = {};
+        }
+        else if (obj[key].length == 1) {
+            obj[key] = obj[key][0];
+        }
+        else {
+            obj[key] = {
+                anyOf: obj[key]
+            };
+        }
+    }
+    if ((key == 'x-required') && Array.isArray(obj[key])) {
+        if (!obj.required) {
+            obj.required = [];
+        }
+        obj.required = obj.required.concat(obj[key]);
+        delete obj[key];
+    }
+    if ((key == '$ref') && (typeof obj[key] === 'string')) {
+        if (obj[key].startsWith('#/definitions/')) {
+            //only the first part of a schema component name must be sanitised
+            let keys = obj[key].replace('#/definitions/','').split('/');
+            keys[0] = componentNames.schemas[keys[0]]; //lookup
+            obj[key] = '#/components/schemas/'+keys.join('/');
+        }
+        if (obj[key].startsWith('#/parameters/')) {
+            // for extensions like Apigee's x-templates
+            obj[key] = '#/components/parameters/'+common.sanitise(obj[key].replace('#/parameters/',''));
+        }
+        if (obj[key].startsWith('#/responses/')) {
+            // for extensions like Apigee's x-templates
+            obj[key] = '#/components/responses/'+common.sanitise(obj[key].replace('#/responses/',''));
+        }
+        Object.keys(obj).forEach(function(k){
+            if (k !== '$ref') delete obj[k];
+        });
+    }
+    if ((key == 'x-ms-odata') && (typeof obj[key] === 'string')) {
+        let keys = obj[key].replace('#/definitions/','').split('/');
+        keys[0] = componentNames.schemas[keys[0]]; //lookup
+        obj[key] = '#/components/schemas/'+keys.join('/');
+    }
 }
 
 function processSecurity(securityObject) {
-	for (let s in securityObject) {
-		for (let k in securityObject[s]) {
-			var sname = common.sanitise(k);
-			if (k != sname) {
-				securityObject[s][sname] = securityObject[s][k];
-				delete securityObject[s][k];
-			}
-		}
-	}
+    for (let s in securityObject) {
+        for (let k in securityObject[s]) {
+            var sname = common.sanitise(k);
+            if (k != sname) {
+                securityObject[s][sname] = securityObject[s][k];
+                delete securityObject[s][k];
+            }
+        }
+    }
 }
 
 function processSecurityScheme(scheme,options) {
-	if (scheme.type == 'basic') {
-		scheme.type = 'http';
-		scheme.scheme = 'basic';
-	}
-	if (scheme.type == 'oauth2') {
-		var flow = {};
-		var flowName = scheme.flow;
-		if (scheme.flow == 'application') flowName = 'clientCredentials';
-		if (scheme.flow == 'accessCode') flowName = 'authorizationCode';
-		if (typeof scheme.authorizationUrl !== 'undefined') flow.authorizationUrl = scheme.authorizationUrl||'/';
-		if (typeof scheme.tokenUrl !== 'undefined') flow.tokenUrl = scheme.tokenUrl||'/';
-		flow.scopes = scheme.scopes||{};
-		scheme.flows = {};
-		scheme.flows[flowName] = flow;
-		delete scheme.flow;
-		delete scheme.authorizationUrl;
-		delete scheme.tokenUrl;
-		delete scheme.scopes;
-		if (typeof scheme.name !== 'undefined') {
-			if (options.patch) {
-				delete scheme.name;
-			}
-			else {
-				throwError('(Patchable) oauth2 securitySchemes should not have name property',options);
-			}
-		}
-	}
+    if (scheme.type == 'basic') {
+        scheme.type = 'http';
+        scheme.scheme = 'basic';
+    }
+    if (scheme.type == 'oauth2') {
+        var flow = {};
+        var flowName = scheme.flow;
+        if (scheme.flow == 'application') flowName = 'clientCredentials';
+        if (scheme.flow == 'accessCode') flowName = 'authorizationCode';
+        if (typeof scheme.authorizationUrl !== 'undefined') flow.authorizationUrl = scheme.authorizationUrl||'/';
+        if (typeof scheme.tokenUrl !== 'undefined') flow.tokenUrl = scheme.tokenUrl||'/';
+        flow.scopes = scheme.scopes||{};
+        scheme.flows = {};
+        scheme.flows[flowName] = flow;
+        delete scheme.flow;
+        delete scheme.authorizationUrl;
+        delete scheme.tokenUrl;
+        delete scheme.scopes;
+        if (typeof scheme.name !== 'undefined') {
+            if (options.patch) {
+                delete scheme.name;
+            }
+            else {
+                throwError('(Patchable) oauth2 securitySchemes should not have name property',options);
+            }
+        }
+    }
 }
 
 function deleteParameters(value) {
-	return !value["x-s2o-delete"];
+    return !value["x-s2o-delete"];
 }
 
 function processHeader(header,options) {
-	if (header.$ref) {
-		header.$ref = header.$ref.replace('#/responses/','#/components/responses/');
-	}
-	else {
-		if (header.type && !header.schema) {
-			header.schema = {};
-		}
-		if (header.type) header.schema.type = header.type;
-		if (header.items && header.items.collectionFormat) {
-			if (header.items.type && header.items.type != 'array') {
-				if (header.items.collectionFormat != header.collectionFormat) {
-					throwError('Nested collectionFormats are not supported', options);
-				}
-				delete header.items.collectionFormat;
-			}
-		}
-		if (typeof header.collectionFormat !== 'undefined') {
-			if (header.type != 'array') {
-				if (options.patch) {
-					delete header.collectionFormat;
-				}
-				else {
-					throwError('(Patchable) collectionFormat is only applicable to header.type array',options);
-				}
-			}
-			if (header.collectionFormat == 'csv') {
-				header.style = 'simple';
-			}
-			if (header.collectionFormat == 'ssv') {
-				throwError('collectionFormat:ssv is no longer supported for headers', options); // not lossless
-			}
-			if (header.collectionFormat == 'pipes') {
-				throwError('collectionFormat:pipes is no longer supported for headers', options); // not lossless
-			}
-			if (header.collectionFormat == 'multi') {
-				header.explode = true;
-			}
-			if (header.collectionFormat == 'tsv') {
-				throwError('collectionFormat:tsv is no longer supported', options); // not lossless
-			}
-			delete header.collectionFormat;
-		}
-		delete header.type;
-		for (let prop of common.parameterTypeProperties) {
-			if (typeof header[prop] !== 'undefined') {
-				header.schema[prop] = header[prop];
-				delete header[prop];
-			}
-		}
-		for (let prop of common.arrayProperties) {
-			if (typeof header[prop] !== 'undefined') {
-				header.schema[prop] = header[prop];
-				delete header[prop];
-			}
-		}
-	}
+    if (header.$ref) {
+        header.$ref = header.$ref.replace('#/responses/','#/components/responses/');
+    }
+    else {
+        if (header.type && !header.schema) {
+            header.schema = {};
+        }
+        if (header.type) header.schema.type = header.type;
+        if (header.items && header.items.collectionFormat) {
+            if (header.items.type && header.items.type != 'array') {
+                if (header.items.collectionFormat != header.collectionFormat) {
+                    throwError('Nested collectionFormats are not supported', options);
+                }
+                delete header.items.collectionFormat;
+            }
+        }
+        if (typeof header.collectionFormat !== 'undefined') {
+            if (header.type != 'array') {
+                if (options.patch) {
+                    delete header.collectionFormat;
+                }
+                else {
+                    throwError('(Patchable) collectionFormat is only applicable to header.type array',options);
+                }
+            }
+            if (header.collectionFormat == 'csv') {
+                header.style = 'simple';
+            }
+            if (header.collectionFormat == 'ssv') {
+                throwError('collectionFormat:ssv is no longer supported for headers', options); // not lossless
+            }
+            if (header.collectionFormat == 'pipes') {
+                throwError('collectionFormat:pipes is no longer supported for headers', options); // not lossless
+            }
+            if (header.collectionFormat == 'multi') {
+                header.explode = true;
+            }
+            if (header.collectionFormat == 'tsv') {
+                throwError('collectionFormat:tsv is no longer supported', options); // not lossless
+            }
+            delete header.collectionFormat;
+        }
+        delete header.type;
+        for (let prop of common.parameterTypeProperties) {
+            if (typeof header[prop] !== 'undefined') {
+                header.schema[prop] = header[prop];
+                delete header[prop];
+            }
+        }
+        for (let prop of common.arrayProperties) {
+            if (typeof header[prop] !== 'undefined') {
+                header.schema[prop] = header[prop];
+                delete header[prop];
+            }
+        }
+    }
 }
 
 function fixParamRef(param) {
-	if (param.$ref.indexOf('#/parameters/')>=0) {
-		let refComponents = param.$ref.split('#/parameters/');
-		param.$ref = refComponents[0]+'#/components/parameters/'+common.sanitise(refComponents[1]);
-	}
-	if (param.$ref.indexOf('#/definitions/')>=0) {
-		throwError('Definition used as parameter',options);
-	}
+    if (param.$ref.indexOf('#/parameters/')>=0) {
+        let refComponents = param.$ref.split('#/parameters/');
+        param.$ref = refComponents[0]+'#/components/parameters/'+common.sanitise(refComponents[1]);
+    }
+    if (param.$ref.indexOf('#/definitions/')>=0) {
+        throwError('Definition used as parameter',options);
+    }
 }
 
 /**
  * @returns requestBody
  */
 function processParameter(param,op,path,index,openapi,options) {
-	var result = {};
-	var singularRequestBody = true;
+    var result = {};
+    var singularRequestBody = true;
 
-	var consumes = ((op && op.consumes)||[]).concat(openapi.consumes||[]);
-	consumes = consumes.filter(common.uniqueOnly);
+    var consumes = ((op && op.consumes)||[]).concat(openapi.consumes||[]);
+    consumes = consumes.filter(common.uniqueOnly);
 
-	if (param.$ref && (typeof param.$ref === 'string')) {
-		// if we still have a ref here, it must be an internal one
-		fixParamRef(param);
-		var ptr = param.$ref.replace('#/components/parameters/','');
-		var rbody = false;
-		let target = openapi.components.parameters[ptr]; // resolves a $ref, must have been sanitised already
+    if (param.$ref && (typeof param.$ref === 'string')) {
+        // if we still have a ref here, it must be an internal one
+        fixParamRef(param);
+        var ptr = param.$ref.replace('#/components/parameters/','');
+        var rbody = false;
+        let target = openapi.components.parameters[ptr]; // resolves a $ref, must have been sanitised already
 
-		if (((!target) || (target["x-s2o-delete"])) && param.$ref.startsWith('#/')) {
-			// if it's gone, chances are it's a requestBody component now unless spec was broken
-			param["x-s2o-delete"] = true;
-			rbody = true;
-		}
+        if (((!target) || (target["x-s2o-delete"])) && param.$ref.startsWith('#/')) {
+            // if it's gone, chances are it's a requestBody component now unless spec was broken
+            param["x-s2o-delete"] = true;
+            rbody = true;
+        }
 
-		// shared formData parameters from swagger or path level could be used in any combination.
-		// we dereference all op.requestBody's then hash them and pull out common ones later
+        // shared formData parameters from swagger or path level could be used in any combination.
+        // we dereference all op.requestBody's then hash them and pull out common ones later
 
-		if (rbody) {
-			let ref = param.$ref;
-			let newParam = common.resolveInternal(openapi,param.$ref);
-			if (!newParam && ref.startsWith('#/')) {
-				throwError('Could not resolve reference '+ref,options);
-			}
-			else {
-				if (newParam) param = newParam; // preserve reference
-			}
-		}
-	}
+        if (rbody) {
+            let ref = param.$ref;
+            let newParam = common.resolveInternal(openapi,param.$ref);
+            if (!newParam && ref.startsWith('#/')) {
+                throwError('Could not resolve reference '+ref,options);
+            }
+            else {
+                if (newParam) param = newParam; // preserve reference
+            }
+        }
+    }
 
-	if (param.name || param.in) { // if it's a real parameter OR we've dereferenced it
+    if (param.name || param.in) { // if it's a real parameter OR we've dereferenced it
 
-		if (typeof param['x-deprecated'] === 'boolean') {
-			param.deprecated = param['x-deprecated'];
-			delete param['x-deprecated'];
-		}
+        if (typeof param['x-deprecated'] === 'boolean') {
+            param.deprecated = param['x-deprecated'];
+            delete param['x-deprecated'];
+        }
 
-		if ((param.in != 'body') && (!param.type)) {
-			if (options.patch) {
-				param.type = 'string';
-			}
-			else {
-				throwError('(Patchable) parameter.type is mandatory for non-body parameters',options);
-			}
-		}
+        if ((param.in != 'body') && (!param.type)) {
+            if (options.patch) {
+                param.type = 'string';
+            }
+            else {
+                throwError('(Patchable) parameter.type is mandatory for non-body parameters',options);
+            }
+        }
 
-		var oldCollectionFormat = param.collectionFormat;
-		if (param.collectionFormat) {
-			if (param.type != 'array') {
-				if (options.patch) {
-					delete param.collectionFormat;
-				}
-				else {
-					throwError('(Patchable) collectionFormat is only applicable to param.type array',options);
-				}
-			}
-			if ((param.collectionFormat == 'csv') && ((param.in == 'query') || (param.in == 'cookie'))) {
-				param.style = 'form';
-			}
-			if ((param.collectionFormat == 'csv') && ((param.in == 'path') || (param.in == 'header'))) {
-				param.style = 'simple';
-			}
-			if (param.collectionFormat == 'ssv') {
-				if (param.in == 'query') {
-					param.style = 'spaceDelimited';
-				}
-				else {
-					throwError('collectionFormat:ssv is no longer supported except for in:query parameters', options); // not lossless
-				}
-			}
-			if (param.collectionFormat == 'pipes') {
-				if (param.in == 'query') {
-					param.style = 'pipeDelimited';
-				}
-				else {
-					throwError('collectionFormat:pipes is no longer supported except for in:query parameters', options); // not lossless
-				}
-			}
-			if (param.collectionFormat == 'multi') {
-				param.explode = true;
-			}
-			if (param.collectionFormat == 'tsv') {
-				throwError('collectionFormat:tsv is no longer supported', options); // not lossless
-			}
-			delete param.collectionFormat;
-		}
+        var oldCollectionFormat = param.collectionFormat;
+        if (param.collectionFormat) {
+            if (param.type != 'array') {
+                if (options.patch) {
+                    delete param.collectionFormat;
+                }
+                else {
+                    throwError('(Patchable) collectionFormat is only applicable to param.type array',options);
+                }
+            }
+            if ((param.collectionFormat == 'csv') && ((param.in == 'query') || (param.in == 'cookie'))) {
+                param.style = 'form';
+            }
+            if ((param.collectionFormat == 'csv') && ((param.in == 'path') || (param.in == 'header'))) {
+                param.style = 'simple';
+            }
+            if (param.collectionFormat == 'ssv') {
+                if (param.in == 'query') {
+                    param.style = 'spaceDelimited';
+                }
+                else {
+                    throwError('collectionFormat:ssv is no longer supported except for in:query parameters', options); // not lossless
+                }
+            }
+            if (param.collectionFormat == 'pipes') {
+                if (param.in == 'query') {
+                    param.style = 'pipeDelimited';
+                }
+                else {
+                    throwError('collectionFormat:pipes is no longer supported except for in:query parameters', options); // not lossless
+                }
+            }
+            if (param.collectionFormat == 'multi') {
+                param.explode = true;
+            }
+            if (param.collectionFormat == 'tsv') {
+                throwError('collectionFormat:tsv is no longer supported', options); // not lossless
+            }
+            delete param.collectionFormat;
+        }
 
-		if (param.type && (param.type != 'object') && (param.type != 'body') && (param.in != 'formData')) {
-			if (param.items && param.schema) {
-				throwError('parameter has array,items and schema',options);
-			}
-			else {
-				if ((!param.schema) || (typeof param.schema !== 'object')) param.schema = {};
-				param.schema.type = param.type;
-				if (param.items) {
-					param.schema.items = param.items;
-					delete param.items;
-					common.recurse(param.schema.items,null,function(obj,key,state){
-						if ((key == 'collectionFormat') && (typeof obj[key] == 'string')) {
-							if (oldCollectionFormat && obj[key] !== oldCollectionFormat) {
-								throwError('Nested collectionFormats are not supported', options);
-							}
-							delete obj[key]; // not lossless
-						}
-						// TODO recursively process items
-					});
-				}
-				for (let prop of common.parameterTypeProperties) {
-					if (typeof param[prop] !== 'undefined') param.schema[prop] = param[prop];
-					delete param[prop];
-				}
-			}
-		}
+        if (param.type && (param.type != 'object') && (param.type != 'body') && (param.in != 'formData')) {
+            if (param.items && param.schema) {
+                throwError('parameter has array,items and schema',options);
+            }
+            else {
+                if ((!param.schema) || (typeof param.schema !== 'object')) param.schema = {};
+                param.schema.type = param.type;
+                if (param.items) {
+                    param.schema.items = param.items;
+                    delete param.items;
+                    common.recurse(param.schema.items,null,function(obj,key,state){
+                        if ((key == 'collectionFormat') && (typeof obj[key] == 'string')) {
+                            if (oldCollectionFormat && obj[key] !== oldCollectionFormat) {
+                                throwError('Nested collectionFormats are not supported', options);
+                            }
+                            delete obj[key]; // not lossless
+                        }
+                        // TODO recursively process items
+                    });
+                }
+                for (let prop of common.parameterTypeProperties) {
+                    if (typeof param[prop] !== 'undefined') param.schema[prop] = param[prop];
+                    delete param[prop];
+                }
+            }
+        }
 
-		if (param.schema) {
-			common.recurse(param.schema,{payload:{targetted:true}},fixupSchema);
-		}
+        if (param.schema) {
+            common.recurse(param.schema,{payload:{targetted:true}},fixupSchema);
+        }
 
-		if (param["x-ms-skip-url-encoding"]) {
-			param.allowReserved = true;
-			if (param.in === 'query') {
-				delete param["x-ms-skip-url-encoding"]; // might be in:path, not allowed in OAS3
-			}
-		}
-	}
+        if (param["x-ms-skip-url-encoding"]) {
+            param.allowReserved = true;
+            if (param.in === 'query') {
+                delete param["x-ms-skip-url-encoding"]; // might be in:path, not allowed in OAS3
+            }
+        }
+    }
 
-	if (param.in == 'formData') {
-		// convert to requestBody component
-		singularRequestBody = false;
-		result.content = {};
-		var contentType = 'application/x-www-form-urlencoded';
-		if ((consumes.length) && (consumes.indexOf('multipart/form-data')>0)) {
-			contentType = 'multipart/form-data';
-		}
+    if (param.in == 'formData') {
+        // convert to requestBody component
+        singularRequestBody = false;
+        result.content = {};
+        var contentType = 'application/x-www-form-urlencoded';
+        if ((consumes.length) && (consumes.indexOf('multipart/form-data')>0)) {
+            contentType = 'multipart/form-data';
+        }
 
-		result.content[contentType] = {};
-		if (param.schema) {
-			result.content[contentType].schema = param.schema;
-			if (param.schema.$ref) {
-				result['x-s2o-name'] = param.schema.$ref.replace('#/components/schemas/','');
-			}
-		}
-		else {
-			result.content[contentType].schema = {};
-			result.content[contentType].schema.type = 'object';
-			result.content[contentType].schema.properties = {};
-			result.content[contentType].schema.properties[param.name] = {};
-			var schema = result.content[contentType].schema;
-			let target = result.content[contentType].schema.properties[param.name];
-			if (param.description) target.description = param.description;
-			if (param.type) target.type = param.type;
+        result.content[contentType] = {};
+        if (param.schema) {
+            result.content[contentType].schema = param.schema;
+            if (param.schema.$ref) {
+                result['x-s2o-name'] = param.schema.$ref.replace('#/components/schemas/','');
+            }
+        }
+        else {
+            result.content[contentType].schema = {};
+            result.content[contentType].schema.type = 'object';
+            result.content[contentType].schema.properties = {};
+            result.content[contentType].schema.properties[param.name] = {};
+            var schema = result.content[contentType].schema;
+            let target = result.content[contentType].schema.properties[param.name];
+            if (param.description) target.description = param.description;
+            if (param.type) target.type = param.type;
 
-			for (let prop of common.parameterTypeProperties) {
-				if (typeof param[prop] !== 'undefined') target[prop] = param[prop];
-			}
-			if (param.required === true) {
-				if (!schema.required) schema.required = [];
-				schema.required.push(param.name);
-			}
-			if (typeof param.default !== 'undefined') target.default = param.default;
-			if (target.properties) target.properties = param.properties;
-			if (param.allOf) target.allOf = param.allOf; // new are anyOf, oneOf, not, x- vendor extensions?
-			if ((param.type == 'array') && (param.items)) {
-				target.items = param.items;
-			}
-		}
-	}
-	if (param.type == 'file') {
-		// convert to requestBody
-		if (param.required) result.required = param.required;
-		result.content = {};
-		result.content["application/octet-stream"] = {};
-		result.content["application/octet-stream"].schema = {};
-		result.content["application/octet-stream"].schema.type = 'string';
-		result.content["application/octet-stream"].schema.format = 'binary';
-	}
-	if (param.in == 'body') {
-		result.content = {};
-		if (param.name) result['x-s2o-name'] = (op && op.operationId ? common.sanitiseAll(op.operationId) : '') + ('_'+param.name).toCamelCase();
-		if (param.description) result.description = param.description;
-		if (param.required) result.required = param.required;
+            for (let prop of common.parameterTypeProperties) {
+                if (typeof param[prop] !== 'undefined') target[prop] = param[prop];
+            }
+            if (param.required === true) {
+                if (!schema.required) schema.required = [];
+                schema.required.push(param.name);
+            }
+            if (typeof param.default !== 'undefined') target.default = param.default;
+            if (target.properties) target.properties = param.properties;
+            if (param.allOf) target.allOf = param.allOf; // new are anyOf, oneOf, not, x- vendor extensions?
+            if ((param.type == 'array') && (param.items)) {
+                target.items = param.items;
+            }
+        }
+    }
+    if (param.type == 'file') {
+        // convert to requestBody
+        if (param.required) result.required = param.required;
+        result.content = {};
+        result.content["application/octet-stream"] = {};
+        result.content["application/octet-stream"].schema = {};
+        result.content["application/octet-stream"].schema.type = 'string';
+        result.content["application/octet-stream"].schema.format = 'binary';
+    }
+    if (param.in == 'body') {
+        result.content = {};
+        if (param.name) result['x-s2o-name'] = (op && op.operationId ? common.sanitiseAll(op.operationId) : '') + ('_'+param.name).toCamelCase();
+        if (param.description) result.description = param.description;
+        if (param.required) result.required = param.required;
 
-		if (param.schema && param.schema.$ref) {
-			result['x-s2o-name'] = param.schema.$ref.replace('#/components/schemas/','');
-		}
-		else if (param.schema && (param.schema.type == 'array') && param.schema.items && param.schema.items.$ref) {
-			result['x-s2o-name'] = param.schema.items.$ref.replace('#/components/schemas/','')+'Array';
-		}
+        if (param.schema && param.schema.$ref) {
+            result['x-s2o-name'] = param.schema.$ref.replace('#/components/schemas/','');
+        }
+        else if (param.schema && (param.schema.type == 'array') && param.schema.items && param.schema.items.$ref) {
+            result['x-s2o-name'] = param.schema.items.$ref.replace('#/components/schemas/','')+'Array';
+        }
 
-		if (!consumes.length) {
-			consumes.push('application/json'); // TODO verify default
-		}
+        if (!consumes.length) {
+            consumes.push('application/json'); // TODO verify default
+        }
 
-		for (let mimetype of consumes) {
-			result.content[mimetype] = {};
-			result.content[mimetype].schema = common.clone(param.schema)||{};
-			common.recurse(result.content[mimetype].schema,{payload:{targetted:true}},fixupSchema);
-		}
-	}
+        for (let mimetype of consumes) {
+            result.content[mimetype] = {};
+            result.content[mimetype].schema = common.clone(param.schema)||{};
+            common.recurse(result.content[mimetype].schema,{payload:{targetted:true}},fixupSchema);
+        }
+    }
 
-	if (Object.keys(result).length > 0) {
-		param["x-s2o-delete"] = true;
-		// work out where to attach the requestBody
-		if (op) {
-			if (op.requestBody && singularRequestBody) {
-				op.requestBody["x-s2o-overloaded"] = true;
-				let opId = op.operationId||index;
+    if (Object.keys(result).length > 0) {
+        param["x-s2o-delete"] = true;
+        // work out where to attach the requestBody
+        if (op) {
+            if (op.requestBody && singularRequestBody) {
+                op.requestBody["x-s2o-overloaded"] = true;
+                let opId = op.operationId||index;
 
-				throwError('Operation '+opId+' has multiple requestBodies',options);
-			}
-			else {
-				op.requestBody = Object.assign({},op.requestBody); // make sure we have one
-				if ((op.requestBody.content && op.requestBody.content["multipart/form-data"])
-					&& (result.content["multipart/form-data"])) {
-					op.requestBody.content["multipart/form-data"].schema.properties =
-						Object.assign(op.requestBody.content["multipart/form-data"].schema.properties,result.content["multipart/form-data"].schema.properties);
-				}
-				else if ((op.requestBody.content && op.requestBody.content["application/x-www-form-urlencoded"])
-					&& (result.content["application/x-www-form-urlencoded"])) {
-					op.requestBody.content["application/x-www-form-urlencoded"].schema.properties =
-						Object.assign(op.requestBody.content["application/x-www-form-urlencoded"].schema.properties,result.content["application/x-www-form-urlencoded"].schema.properties);
-				}
-				else {
-					op.requestBody = Object.assign(op.requestBody,result);
-					if (!op.requestBody['x-s2o-name']) {
-						if (op.requestBody.schema && op.requestBody.schema.$ref) {
-							op.requestBody['x-s2o-name'] = op.requestBody.schema.$ref.replace('#/components/schemas/','').split('/').join('');
-						}
-						else if (op.operationId) {
-							op.requestBody['x-s2o-name'] = common.sanitiseAll(op.operationId);
-						}
-					}
-				}
-			}
-		}
-	}
+                throwError('Operation '+opId+' has multiple requestBodies',options);
+            }
+            else {
+                op.requestBody = Object.assign({},op.requestBody); // make sure we have one
+                if ((op.requestBody.content && op.requestBody.content["multipart/form-data"])
+                    && (result.content["multipart/form-data"])) {
+                    op.requestBody.content["multipart/form-data"].schema.properties =
+                        Object.assign(op.requestBody.content["multipart/form-data"].schema.properties,result.content["multipart/form-data"].schema.properties);
+                }
+                else if ((op.requestBody.content && op.requestBody.content["application/x-www-form-urlencoded"])
+                    && (result.content["application/x-www-form-urlencoded"])) {
+                    op.requestBody.content["application/x-www-form-urlencoded"].schema.properties =
+                        Object.assign(op.requestBody.content["application/x-www-form-urlencoded"].schema.properties,result.content["application/x-www-form-urlencoded"].schema.properties);
+                }
+                else {
+                    op.requestBody = Object.assign(op.requestBody,result);
+                    if (!op.requestBody['x-s2o-name']) {
+                        if (op.requestBody.schema && op.requestBody.schema.$ref) {
+                            op.requestBody['x-s2o-name'] = op.requestBody.schema.$ref.replace('#/components/schemas/','').split('/').join('');
+                        }
+                        else if (op.operationId) {
+                            op.requestBody['x-s2o-name'] = common.sanitiseAll(op.operationId);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	// tidy up
-	delete param.type;
-	for (let prop of common.parameterTypeProperties) {
-		delete param[prop];
-	}
+    // tidy up
+    delete param.type;
+    for (let prop of common.parameterTypeProperties) {
+        delete param[prop];
+    }
 
-	if ((param.in == 'path') && ((typeof param.required === 'undefined') || (param.required !== true))) {
-		if (options.patch) {
-			param.required = true;
-		}
-		else {
-			throwError('(Patchable) path parameters must be required:true',options);
-		}
-	}
+    if ((param.in == 'path') && ((typeof param.required === 'undefined') || (param.required !== true))) {
+        if (options.patch) {
+            param.required = true;
+        }
+        else {
+            throwError('(Patchable) path parameters must be required:true',options);
+        }
+    }
 
-	return result;
+    return result;
 }
 
 function processResponse(response, name, op, openapi, options) {
-	if (response.$ref && (typeof response.$ref === 'string')) {
-		if (typeof response.description !== 'undefined') {
-			if (options.patch) {
-				delete response.description;
-			}
-			else {
-				throwError('(Patchable) $ref object cannot be extended: ' + response.$ref,options);
-			}
-		}
-		if (response.$ref.indexOf('#/definitions/') >= 0) {
-			//response.$ref = '#/components/schemas/'+common.sanitise(response.$ref.replace('#/definitions/',''));
-			throwError('definition used as response: ' + response.$ref,options);
-		}
-		else {
-			if (response.$ref.startsWith('#/responses/')) {
-				response.$ref = '#/components/responses/' + common.sanitise(response.$ref.replace('#/responses/', ''));
-			}
-		}
-	}
-	else {
-		if ((typeof response.description === 'undefined') || (response.description === null)
-			|| ((response.description === '') && options.patch)) {
-			if (options.patch) {
-				var sc = statusCodes.find(function(e){
-					return e.code == name;
-				});
-				response.description = (sc ? sc.phrase : '');
-			}
-			else {
-				throwError('(Patchable) response.description is mandatory',options);
-			}
-		}
-		if (response.schema) {
+    if (response.$ref && (typeof response.$ref === 'string')) {
+        if (typeof response.description !== 'undefined') {
+            if (options.patch) {
+                delete response.description;
+            }
+            else {
+                throwError('(Patchable) $ref object cannot be extended: ' + response.$ref,options);
+            }
+        }
+        if (response.$ref.indexOf('#/definitions/') >= 0) {
+            //response.$ref = '#/components/schemas/'+common.sanitise(response.$ref.replace('#/definitions/',''));
+            throwError('definition used as response: ' + response.$ref,options);
+        }
+        else {
+            if (response.$ref.startsWith('#/responses/')) {
+                response.$ref = '#/components/responses/' + common.sanitise(response.$ref.replace('#/responses/', ''));
+            }
+        }
+    }
+    else {
+        if ((typeof response.description === 'undefined') || (response.description === null)
+            || ((response.description === '') && options.patch)) {
+            if (options.patch) {
+                var sc = statusCodes.find(function(e){
+                    return e.code == name;
+                });
+                response.description = (sc ? sc.phrase : '');
+            }
+            else {
+                throwError('(Patchable) response.description is mandatory',options);
+            }
+        }
+        if (response.schema) {
 
-			common.recurse(response.schema, {payload:{targetted:true}}, fixupSchema);
+            common.recurse(response.schema, {payload:{targetted:true}}, fixupSchema);
 
-			if (response.schema.$ref && (typeof response.schema.$ref === 'string') && response.schema.$ref.startsWith('#/responses/')) {
-				response.schema.$ref = '#/components/responses/' + common.sanitise(response.schema.$ref.replace('#/responses/', ''));
-			}
+            if (response.schema.$ref && (typeof response.schema.$ref === 'string') && response.schema.$ref.startsWith('#/responses/')) {
+                response.schema.$ref = '#/components/responses/' + common.sanitise(response.schema.$ref.replace('#/responses/', ''));
+            }
 
-			var produces = ((op && op.produces) || []).concat(openapi.produces || []).filter(common.uniqueOnly);
-			if (!produces.length) produces.push('*/*'); // TODO verify default
+            var produces = ((op && op.produces) || []).concat(openapi.produces || []).filter(common.uniqueOnly);
+            if (!produces.length) produces.push('*/*'); // TODO verify default
 
-			response.content = {};
-			for (let mimetype of produces) {
-				response.content[mimetype] = {};
-				response.content[mimetype].schema = common.clone(response.schema);
-				if (response.examples && response.examples[mimetype]) {
-					let example = {};
-					example.value = response.examples[mimetype];
-					response.content[mimetype].examples = {};
-					response.content[mimetype].examples.response = example;
-					delete response.examples[mimetype];
-				}
-				if (response.content[mimetype].schema.type == 'file') {
-					delete response.content[mimetype].schema;
-				}
-			}
-			delete response.schema;
-		}
-		// examples for other types
-		for (let mimetype in response.examples) {
-			if (!response.content) response.content = {};
-			if (!response.content[mimetype]) response.content[mimetype] = {};
-			response.content[mimetype].examples = {};
-			response.content[mimetype].examples.response = {};
-			response.content[mimetype].examples.response.value = response.examples[mimetype];
-		}
-		delete response.examples;
-		if (response.headers) {
-			for (let h in response.headers) {
-				if (h == 'Status Code') {
-					if (options.patch) {
-						delete response.headers[h];
-					}
-					else {
-						throwError('"Status Code" is not a valid header (patchable)', options);
-					}
-				}
-				else {
-					processHeader(response.headers[h],options);
-				}
-			}
-		}
-	}
+            response.content = {};
+            for (let mimetype of produces) {
+                response.content[mimetype] = {};
+                response.content[mimetype].schema = common.clone(response.schema);
+                if (response.examples && response.examples[mimetype]) {
+                    let example = {};
+                    example.value = response.examples[mimetype];
+                    response.content[mimetype].examples = {};
+                    response.content[mimetype].examples.response = example;
+                    delete response.examples[mimetype];
+                }
+                if (response.content[mimetype].schema.type == 'file') {
+                    delete response.content[mimetype].schema;
+                }
+            }
+            delete response.schema;
+        }
+        // examples for other types
+        for (let mimetype in response.examples) {
+            if (!response.content) response.content = {};
+            if (!response.content[mimetype]) response.content[mimetype] = {};
+            response.content[mimetype].examples = {};
+            response.content[mimetype].examples.response = {};
+            response.content[mimetype].examples.response.value = response.examples[mimetype];
+        }
+        delete response.examples;
+        if (response.headers) {
+            for (let h in response.headers) {
+                if (h == 'Status Code') {
+                    if (options.patch) {
+                        delete response.headers[h];
+                    }
+                    else {
+                        throwError('"Status Code" is not a valid header (patchable)', options);
+                    }
+                }
+                else {
+                    processHeader(response.headers[h],options);
+                }
+            }
+        }
+    }
 }
 
 function processPaths(container, containerName, options, requestBodyCache, openapi) {
-	for (let p in container) {
-		var path = container[p];
-		// path.$ref is external only
-		if ((path['x-trace']) && (typeof path['x-trace'] === 'object')) {
-			path.trace = path['x-trace'];
-			delete path['x-trace'];
-		}
-		if ((path['x-summary']) && (typeof path['x-summary'] === 'string')) {
-			path.summary = path['x-summary'];
-			delete path['x-summary'];
-		}
-		if ((path['x-description']) && (typeof path['x-description'] === 'string')) {
-			path.description = path['x-description'];
-			delete path['x-description'];
-		}
-		if ((path['x-servers']) && (Array.isArray(path['x-servers']))) {
-			path.servers = path['x-servers'];
-			delete path['x-servers'];
-		}
-		for (let method in path) {
-			if ((common.httpVerbs.indexOf(method) >= 0) || (method === 'x-amazon-apigateway-any-method')) {
-				var op = path[method];
+    for (let p in container) {
+        var path = container[p];
+        // path.$ref is external only
+        if ((path['x-trace']) && (typeof path['x-trace'] === 'object')) {
+            path.trace = path['x-trace'];
+            delete path['x-trace'];
+        }
+        if ((path['x-summary']) && (typeof path['x-summary'] === 'string')) {
+            path.summary = path['x-summary'];
+            delete path['x-summary'];
+        }
+        if ((path['x-description']) && (typeof path['x-description'] === 'string')) {
+            path.description = path['x-description'];
+            delete path['x-description'];
+        }
+        if ((path['x-servers']) && (Array.isArray(path['x-servers']))) {
+            path.servers = path['x-servers'];
+            delete path['x-servers'];
+        }
+        for (let method in path) {
+            if ((common.httpVerbs.indexOf(method) >= 0) || (method === 'x-amazon-apigateway-any-method')) {
+                var op = path[method];
 
-				if ((op['x-servers']) && (Array.isArray(op['x-servers']))) {
-					op.servers = op['x-servers'];
-					delete op['x-servers'];
-				}
+                if ((op['x-servers']) && (Array.isArray(op['x-servers']))) {
+                    op.servers = op['x-servers'];
+                    delete op['x-servers'];
+                }
 
-				if (op.parameters && Array.isArray(op.parameters)) {
-				    if (path.parameters) {
-						for (let param of path.parameters) {
-							if (typeof param.$ref === 'string') {
-								fixParamRef(param);
-								param = common.resolveInternal(openapi,param.$ref);
-							}
-							var match = op.parameters.find(function(e,i,a){
-								return ((e.name == param.name) && (e.in == param.in));
-							});
+                if (op.parameters && Array.isArray(op.parameters)) {
+                    if (path.parameters) {
+                        for (let param of path.parameters) {
+                            if (typeof param.$ref === 'string') {
+                                fixParamRef(param);
+                                param = common.resolveInternal(openapi,param.$ref);
+                            }
+                            var match = op.parameters.find(function(e,i,a){
+                                return ((e.name == param.name) && (e.in == param.in));
+                            });
 
-							if (!match && (param.in === 'formData') || (param.in === 'body') || (param.type === 'file')) {
-								processParameter(param, op, path, p, openapi, options);
-							}
-						}
-					}
-					for (let param of op.parameters) {
-						processParameter(param, op, path, method+':'+p, openapi, options);
-					}
-					if (!options.debug) {
-						op.parameters = op.parameters.filter(deleteParameters);
-					}
-				}
+                            if (!match && (param.in === 'formData') || (param.in === 'body') || (param.type === 'file')) {
+                                processParameter(param, op, path, p, openapi, options);
+                            }
+                        }
+                    }
+                    for (let param of op.parameters) {
+                        processParameter(param, op, path, method+':'+p, openapi, options);
+                    }
+                    if (!options.debug) {
+                        op.parameters = op.parameters.filter(deleteParameters);
+                    }
+                }
 
-				if (op.security) processSecurity(op.security);
+                if (op.security) processSecurity(op.security);
 
-				//don't need to remove requestBody for non-supported ops "SHALL be ignored"
+                //don't need to remove requestBody for non-supported ops "SHALL be ignored"
 
-				// responses
-				if (!op.responses) {
-					var defaultResp = {};
-					defaultResp.description = 'Default response';
-					op.responses = { default: defaultResp };
-				}
-				for (let r in op.responses) {
-					var response = op.responses[r];
-					processResponse(response,r,op,openapi,options);
-				}
+                // responses
+                if (!op.responses) {
+                    var defaultResp = {};
+                    defaultResp.description = 'Default response';
+                    op.responses = { default: defaultResp };
+                }
+                for (let r in op.responses) {
+                    var response = op.responses[r];
+                    processResponse(response,r,op,openapi,options);
+                }
 
-				if (op.schemes && op.schemes.length) {
-					for (let scheme of op.schemes) {
-						if ((!openapi.schemes) || (openapi.schemes.indexOf(scheme) < 0)) {
-							if (!op.servers) {
-								op.servers = [];
-							}
-							for (let server of openapi.servers) {
-								let newServer = common.clone(server);
-								let serverUrl = url.parse(newServer.url);
-								serverUrl.protocol = scheme;
-								newServer.url = serverUrl.format();
-								op.servers.push(newServer);
-							}
-						}
-					}
-				}
+                if (op.schemes && op.schemes.length) {
+                    for (let scheme of op.schemes) {
+                        if ((!openapi.schemes) || (openapi.schemes.indexOf(scheme) < 0)) {
+                            if (!op.servers) {
+                                op.servers = [];
+                            }
+                            for (let server of openapi.servers) {
+                                let newServer = common.clone(server);
+                                let serverUrl = url.parse(newServer.url);
+                                serverUrl.protocol = scheme;
+                                newServer.url = serverUrl.format();
+                                op.servers.push(newServer);
+                            }
+                        }
+                    }
+                }
 
-				if (options.debug) {
-					op["x-s2o-consumes"] = op.consumes || [];
-					op["x-s2o-produces"] = op.produces || [];
-				}
-				delete op.consumes;
-				delete op.produces;
-				delete op.schemes;
-				if (op.parameters && op.parameters.length === 0) delete op.parameters;
+                if (options.debug) {
+                    op["x-s2o-consumes"] = op.consumes || [];
+                    op["x-s2o-produces"] = op.produces || [];
+                }
+                delete op.consumes;
+                delete op.produces;
+                delete op.schemes;
+                if (op.parameters && op.parameters.length === 0) delete op.parameters;
 
-				common.recurse(op, {payload:{targetted:false}}, fixupSchema); // for x-ms-odata etc
+                common.recurse(op, {payload:{targetted:false}}, fixupSchema); // for x-ms-odata etc
 
-				if (op.requestBody) {
-					var effectiveOperationId = op.operationId ? common.sanitiseAll(op.operationId) : common.sanitiseAll(method+p).toCamelCase();
-					var rbName = common.sanitise(op.requestBody['x-s2o-name']||effectiveOperationId||'');
-					delete op.requestBody['x-s2o-name'];
-					var rbStr = JSON.stringify(op.requestBody);
-					var rbSha256 = common.sha256(rbStr);
-					if (!requestBodyCache[rbSha256]) {
-						var entry = {};
-						entry.name = rbName;
-						entry.body = op.requestBody;
-						entry.refs = [];
-						requestBodyCache[rbSha256] = entry;
-					}
-					requestBodyCache[rbSha256].refs.push(containerName + ' ' + method + ' ' + p); // might be easier to use a JSON Pointer here
-				}
+                if (op.requestBody) {
+                    var effectiveOperationId = op.operationId ? common.sanitiseAll(op.operationId) : common.sanitiseAll(method+p).toCamelCase();
+                    var rbName = common.sanitise(op.requestBody['x-s2o-name']||effectiveOperationId||'');
+                    delete op.requestBody['x-s2o-name'];
+                    var rbStr = JSON.stringify(op.requestBody);
+                    var rbSha256 = common.sha256(rbStr);
+                    if (!requestBodyCache[rbSha256]) {
+                        var entry = {};
+                        entry.name = rbName;
+                        entry.body = op.requestBody;
+                        entry.refs = [];
+                        requestBodyCache[rbSha256] = entry;
+                    }
+                    requestBodyCache[rbSha256].refs.push(containerName + ' ' + method + ' ' + p); // might be easier to use a JSON Pointer here
+                }
 
-			}
-		}
-		if (path.parameters) {
-			for (let p2 in path.parameters) {
-				var param = path.parameters[p2];
-				processParameter(param, null, path, p, openapi, options); // index here is the path string
-			}
-			if (!options.debug) {
-				path.parameters = path.parameters.filter(deleteParameters);
-			}
-		}
-	}
+            }
+        }
+        if (path.parameters) {
+            for (let p2 in path.parameters) {
+                var param = path.parameters[p2];
+                processParameter(param, null, path, p, openapi, options); // index here is the path string
+            }
+            if (!options.debug) {
+                path.parameters = path.parameters.filter(deleteParameters);
+            }
+        }
+    }
 }
 
 function main(openapi, options) {
 
-	var requestBodyCache = {};
-	componentNames = {schemas:{}};
+    var requestBodyCache = {};
+    componentNames = {schemas:{}};
 
-	if (openapi.security) processSecurity(openapi.security);
+    if (openapi.security) processSecurity(openapi.security);
 
-	for (let s in openapi.components.securitySchemes) {
-		let sname = common.sanitise(s);
-		if (s != sname) {
-			if (openapi.components.securitySchemes[sname]) {
-				throwError('Duplicate sanitised securityScheme name '+sname,options);
-			}
-			openapi.components.securitySchemes[sname] = openapi.components.securitySchemes[s];
-			delete openapi.components.securitySchemes[s];
-		}
-		processSecurityScheme(openapi.components.securitySchemes[sname],options);
-	}
+    for (let s in openapi.components.securitySchemes) {
+        let sname = common.sanitise(s);
+        if (s != sname) {
+            if (openapi.components.securitySchemes[sname]) {
+                throwError('Duplicate sanitised securityScheme name '+sname,options);
+            }
+            openapi.components.securitySchemes[sname] = openapi.components.securitySchemes[s];
+            delete openapi.components.securitySchemes[s];
+        }
+        processSecurityScheme(openapi.components.securitySchemes[sname],options);
+    }
 
-	for (let s in openapi.components.schemas) {
-		let sname = common.sanitiseAll(s);
-		let suffix = '';
-		if (s != sname) {
-			while (openapi.components.schemas[sname+suffix]) {
-				// @ts-ignore
-				suffix = (suffix ? ++suffix : 2);
-			}
-			openapi.components.schemas[sname+suffix] = openapi.components.schemas[s];
-			delete openapi.components.schemas[s];
-		}
-		componentNames.schemas[s] = sname+suffix;
-	}
+    for (let s in openapi.components.schemas) {
+        let sname = common.sanitiseAll(s);
+        let suffix = '';
+        if (s != sname) {
+            while (openapi.components.schemas[sname+suffix]) {
+                // @ts-ignore
+                suffix = (suffix ? ++suffix : 2);
+            }
+            openapi.components.schemas[sname+suffix] = openapi.components.schemas[s];
+            delete openapi.components.schemas[s];
+        }
+        componentNames.schemas[s] = sname+suffix;
+    }
 
-	for (let p in openapi.components.parameters) {
-		let sname = common.sanitise(p);
-		if (p != sname) {
-			if (openapi.components.parameters[sname]) {
-				throwError('Duplicate sanitised parameter name '+sname,options);
-			}
-			openapi.components.parameters[sname] = openapi.components.parameters[p];
-			delete openapi.components.parameters[p];
-		}
-		var param = openapi.components.parameters[sname];
-		processParameter(param,null,null,sname,openapi,options);
-	}
+    for (let p in openapi.components.parameters) {
+        let sname = common.sanitise(p);
+        if (p != sname) {
+            if (openapi.components.parameters[sname]) {
+                throwError('Duplicate sanitised parameter name '+sname,options);
+            }
+            openapi.components.parameters[sname] = openapi.components.parameters[p];
+            delete openapi.components.parameters[p];
+        }
+        var param = openapi.components.parameters[sname];
+        processParameter(param,null,null,sname,openapi,options);
+    }
 
-	common.recurse(openapi.components.responses,{payload:{targetted:false}},fixupSchema);
-	for (let r in openapi.components.responses) {
-		let sname = common.sanitise(r);
-		if (r != sname) {
-			if (openapi.components.responses[sname]) {
-				throwError('Duplicate sanitised response name '+sname,options);
-			}
-			openapi.components.responses[sname] = openapi.components.responses[r];
-			delete openapi.components.responses[r];
-		}
-		var response = openapi.components.responses[sname];
-		processResponse(response,sname,null,openapi,options);
-		if (response.headers) {
-			for (let h in response.headers) {
-				if (h == 'Status Code') {
-					if (options.patch) {
-						delete response.headers[h];
-					}
-					else {
-						throwError('"Status Code" is not a valid header (patchable)', options);
-					}
-				}
-				else {
-					processHeader(response.headers[h],options);
-				}
-			}
-		}
-	}
+    common.recurse(openapi.components.responses,{payload:{targetted:false}},fixupSchema);
+    for (let r in openapi.components.responses) {
+        let sname = common.sanitise(r);
+        if (r != sname) {
+            if (openapi.components.responses[sname]) {
+                throwError('Duplicate sanitised response name '+sname,options);
+            }
+            openapi.components.responses[sname] = openapi.components.responses[r];
+            delete openapi.components.responses[r];
+        }
+        var response = openapi.components.responses[sname];
+        processResponse(response,sname,null,openapi,options);
+        if (response.headers) {
+            for (let h in response.headers) {
+                if (h == 'Status Code') {
+                    if (options.patch) {
+                        delete response.headers[h];
+                    }
+                    else {
+                        throwError('"Status Code" is not a valid header (patchable)', options);
+                    }
+                }
+                else {
+                    processHeader(response.headers[h],options);
+                }
+            }
+        }
+    }
 
-	for (let r in openapi.components.requestBodies) { // converted ones
-		var rb = openapi.components.requestBodies[r];
-		var rbStr = JSON.stringify(rb);
-		var rbSha256 = common.sha256(rbStr);
-		let entry = {};
-		entry.name = r;
-		entry.body = rb;
-		entry.refs = [];
-		requestBodyCache[rbSha256] = entry;
-	}
+    for (let r in openapi.components.requestBodies) { // converted ones
+        var rb = openapi.components.requestBodies[r];
+        var rbStr = JSON.stringify(rb);
+        var rbSha256 = common.sha256(rbStr);
+        let entry = {};
+        entry.name = r;
+        entry.body = rb;
+        entry.refs = [];
+        requestBodyCache[rbSha256] = entry;
+    }
 
-	processPaths(openapi.paths,'paths',options,requestBodyCache,openapi);
-	if (openapi["x-ms-paths"]) {
-		processPaths(openapi["x-ms-paths"],'x-ms-paths',options,requestBodyCache,openapi);
-	}
+    processPaths(openapi.paths,'paths',options,requestBodyCache,openapi);
+    if (openapi["x-ms-paths"]) {
+        processPaths(openapi["x-ms-paths"],'x-ms-paths',options,requestBodyCache,openapi);
+    }
 
-	if (!options.debug) {
-		for (let p in openapi.components.parameters) {
-			param = openapi.components.parameters[p];
-			if (param["x-s2o-delete"]) {
-				delete openapi.components.parameters[p];
-			}
-		}
-	}
+    if (!options.debug) {
+        for (let p in openapi.components.parameters) {
+            param = openapi.components.parameters[p];
+            if (param["x-s2o-delete"]) {
+                delete openapi.components.parameters[p];
+            }
+        }
+    }
 
-	common.recurse(openapi.components.schemas,{payload:{targetted:true}},fixupSchema);
-	common.recurse(openapi.components.schemas,{payload:{targetted:true}},fixupSchema); // second pass for fixed x-anyOf's etc
-	common.recurse(openapi,{payload:{targetted:false}},fixupSchema); // pass across whole definition for $refs in vendor extensions
-	common.recurse(openapi,{payload:{targetted:false}},fixupSchema); // second pass for fixed x-anyOf's etc
+    common.recurse(openapi.components.schemas,{payload:{targetted:true}},fixupSchema);
+    common.recurse(openapi.components.schemas,{payload:{targetted:true}},fixupSchema); // second pass for fixed x-anyOf's etc
+    common.recurse(openapi,{payload:{targetted:false}},fixupSchema); // pass across whole definition for $refs in vendor extensions
+    common.recurse(openapi,{payload:{targetted:false}},fixupSchema); // second pass for fixed x-anyOf's etc
 
-	if (options.debug) {
-		openapi["x-s2o-consumes"] = openapi.consumes||[];
-		openapi["x-s2o-produces"] = openapi.produces||[];
-	}
-	delete openapi.consumes;
-	delete openapi.produces;
-	delete openapi.schemes;
+    if (options.debug) {
+        openapi["x-s2o-consumes"] = openapi.consumes||[];
+        openapi["x-s2o-produces"] = openapi.produces||[];
+    }
+    delete openapi.consumes;
+    delete openapi.produces;
+    delete openapi.schemes;
 
-	var rbNamesGenerated = [];
+    var rbNamesGenerated = [];
 
-	openapi.components.requestBodies = {}; // for now as we've dereffed them
+    openapi.components.requestBodies = {}; // for now as we've dereffed them
 
-	var counter = 1;
-	for (let e in requestBodyCache) {
-		let entry = requestBodyCache[e];
-		if (entry.refs.length>1) {
-			// create a shared requestBody
-			var suffix = '';
-			if (!entry.name) {
-				entry.name = 'requestBody';
-				// @ts-ignore
-				suffix = counter++;
-			}
-			while (rbNamesGenerated.indexOf(entry.name+suffix)>=0) {
-				// @ts-ignore - this can happen if descriptions are not exactly the same (e.g. bitbucket)
-				suffix = (suffix ? ++suffix : 2);
-			}
-			entry.name = entry.name+suffix;
-			rbNamesGenerated.push(entry.name);
-			openapi.components.requestBodies[entry.name] = entry.body;
-			for (let r in entry.refs) {
-				var address = entry.refs[r].split(' ');
-				var ref = {};
-				ref.$ref = '#/components/requestBodies/'+entry.name;
-				openapi[address[0]][address[2]][address[1]].requestBody = ref; // might be easier to use a JSON Pointer here
-			}
-		}
-	}
+    var counter = 1;
+    for (let e in requestBodyCache) {
+        let entry = requestBodyCache[e];
+        if (entry.refs.length>1) {
+            // create a shared requestBody
+            var suffix = '';
+            if (!entry.name) {
+                entry.name = 'requestBody';
+                // @ts-ignore
+                suffix = counter++;
+            }
+            while (rbNamesGenerated.indexOf(entry.name+suffix)>=0) {
+                // @ts-ignore - this can happen if descriptions are not exactly the same (e.g. bitbucket)
+                suffix = (suffix ? ++suffix : 2);
+            }
+            entry.name = entry.name+suffix;
+            rbNamesGenerated.push(entry.name);
+            openapi.components.requestBodies[entry.name] = entry.body;
+            for (let r in entry.refs) {
+                var address = entry.refs[r].split(' ');
+                var ref = {};
+                ref.$ref = '#/components/requestBodies/'+entry.name;
+                openapi[address[0]][address[2]][address[1]].requestBody = ref; // might be easier to use a JSON Pointer here
+            }
+        }
+    }
 
-	if (openapi.components.responses && Object.keys(openapi.components.responses).length === 0) {
-		delete openapi.components.responses;
-	}
-	if (openapi.components.parameters && Object.keys(openapi.components.parameters).length === 0) {
-		delete openapi.components.parameters;
-	}
-	if (openapi.components.examples && Object.keys(openapi.components.examples).length === 0) {
-		delete openapi.components.examples;
-	}
-	if (openapi.components.requestBodies && Object.keys(openapi.components.requestBodies).length === 0) {
-		delete openapi.components.requestBodies;
-	}
-	if (openapi.components.securitySchemes && Object.keys(openapi.components.securitySchemes).length === 0) {
-		delete openapi.components.securitySchemes;
-	}
-	if (openapi.components.headers && Object.keys(openapi.components.headers).length === 0) {
-		delete openapi.components.headers;
-	}
+    if (openapi.components.responses && Object.keys(openapi.components.responses).length === 0) {
+        delete openapi.components.responses;
+    }
+    if (openapi.components.parameters && Object.keys(openapi.components.parameters).length === 0) {
+        delete openapi.components.parameters;
+    }
+    if (openapi.components.examples && Object.keys(openapi.components.examples).length === 0) {
+        delete openapi.components.examples;
+    }
+    if (openapi.components.requestBodies && Object.keys(openapi.components.requestBodies).length === 0) {
+        delete openapi.components.requestBodies;
+    }
+    if (openapi.components.securitySchemes && Object.keys(openapi.components.securitySchemes).length === 0) {
+        delete openapi.components.securitySchemes;
+    }
+    if (openapi.components.headers && Object.keys(openapi.components.headers).length === 0) {
+        delete openapi.components.headers;
+    }
 
-	return openapi;
+    return openapi;
 }
 
 function convertObj(swagger, options, callback) {
-	return maybe(callback, new Promise(function(resolve, reject) {
-		if (swagger.openapi && (typeof swagger.openapi === 'string') && swagger.openapi.startsWith('3.')) {
-			options.openapi = swagger;
-			return resolve(options);
-		}
-		if ((!swagger.swagger) || (swagger.swagger != "2.0")) {
-			return reject(new Error('Unsupported swagger/OpenAPI version: '+swagger.swagger));
-		}
+    return maybe(callback, new Promise(function(resolve, reject) {
+        if (swagger.openapi && (typeof swagger.openapi === 'string') && swagger.openapi.startsWith('3.')) {
+            options.openapi = swagger;
+            return resolve(options);
+        }
+        if ((!swagger.swagger) || (swagger.swagger != "2.0")) {
+            return reject(new Error('Unsupported swagger/OpenAPI version: '+swagger.swagger));
+        }
 
-		var openapi = options.openapi = {};
-		openapi.openapi = targetVersion; // semver
-		openapi.servers = [];
+        var openapi = options.openapi = {};
+        openapi.openapi = targetVersion; // semver
+        openapi.servers = [];
 
-		if (options.origin) {
-			if (!openapi["x-origin"]) {
-				openapi["x-origin"] = [];
-			}
-			var origin = {};
-			origin.url = options.origin;
-			origin.format = 'swagger';
-			origin.version = swagger.swagger;
-			origin.converter = {};
-			origin.converter.url = 'https://github.com/mermade/swagger2openapi';
-			origin.converter.version = common.getVersion();
-			openapi["x-origin"].push(origin);
-		}
+        if (options.origin) {
+            if (!openapi["x-origin"]) {
+                openapi["x-origin"] = [];
+            }
+            var origin = {};
+            origin.url = options.origin;
+            origin.format = 'swagger';
+            origin.version = swagger.swagger;
+            origin.converter = {};
+            origin.converter.url = 'https://github.com/mermade/swagger2openapi';
+            origin.converter.version = common.getVersion();
+            openapi["x-origin"].push(origin);
+        }
 
-		// we want the new and existing properties to appear in a sensible order. Not guaranteed
-		openapi = Object.assign(openapi,common.clone(swagger));
-		delete openapi.swagger;
+        // we want the new and existing properties to appear in a sensible order. Not guaranteed
+        openapi = Object.assign(openapi,common.clone(swagger));
+        delete openapi.swagger;
 
-		if (swagger.host && swagger.schemes) {
-			for (let s of swagger.schemes) {
-				let server = {};
-				server.url = s + '://' + swagger.host + (swagger.basePath ? swagger.basePath : '/');
-				server.url = server.url.split('{{').join('{');
-				server.url = server.url.split('}}').join('}');
-				server.url.replace(/\{(.+?)\}/g,function(match,group1) { // TODO extend to :parameters (not port)?
-					if (!server.variables) {
-						server.variables = {};
-					}
-					server.variables[group1] = {default: 'unknown'};
-				});
-				openapi.servers.push(server);
-			}
-		}
-		else if (swagger.basePath) {
-			let server = {};
-			server.url = swagger.basePath;
-			openapi.servers.push(server);
-		}
-		delete openapi.host;
-		delete openapi.basePath;
+        if (swagger.host && swagger.schemes) {
+            for (let s of swagger.schemes) {
+                let server = {};
+                server.url = s + '://' + swagger.host + (swagger.basePath ? swagger.basePath : '/');
+                server.url = server.url.split('{{').join('{');
+                server.url = server.url.split('}}').join('}');
+                server.url.replace(/\{(.+?)\}/g,function(match,group1) { // TODO extend to :parameters (not port)?
+                    if (!server.variables) {
+                        server.variables = {};
+                    }
+                    server.variables[group1] = {default: 'unknown'};
+                });
+                openapi.servers.push(server);
+            }
+        }
+        else if (swagger.basePath) {
+            let server = {};
+            server.url = swagger.basePath;
+            openapi.servers.push(server);
+        }
+        delete openapi.host;
+        delete openapi.basePath;
 
-		if (openapi['x-servers'] && Array.isArray(openapi['x-servers'])) {
-			openapi.servers = openapi['x-servers'].concat(openapi.servers);
-			delete openapi['x-servers'];
-		}
+        if (openapi['x-servers'] && Array.isArray(openapi['x-servers'])) {
+            openapi.servers = openapi['x-servers'].concat(openapi.servers);
+            delete openapi['x-servers'];
+        }
 
-		// TODO APIMatic extensions (x-server-configuration) ?
+        // TODO APIMatic extensions (x-server-configuration) ?
 
-		if (swagger['x-ms-parameterized-host']) {
-			var xMsPHost = swagger['x-ms-parameterized-host'];
-			let server = {};
-			server.url = xMsPHost.hostTemplate;
-			server.variables = {};
-			for (let param of xMsPHost.parameters) {
-				if (param.$ref) {
-					param.$ref = common.resolveInternal(openapi,param.$ref);
-				}
-				delete param.required; // all true
-				delete param.type; // all strings
-				delete param.in; // all 'host'
-				if (typeof param.default === 'undefined') {
-					if (param.enum) {
-						param.default = param.enum[0];
-					}
-					else {
-						param.default = '';
-					}
-				}
-				server.variables[param.name] = param;
-				delete param.name;
-			}
-			openapi.servers.push(server);
-			delete openapi['x-ms-parameterized-host'];
-		}
+        if (swagger['x-ms-parameterized-host']) {
+            var xMsPHost = swagger['x-ms-parameterized-host'];
+            let server = {};
+            server.url = xMsPHost.hostTemplate;
+            server.variables = {};
+            for (let param of xMsPHost.parameters) {
+                if (param.$ref) {
+                    param.$ref = common.resolveInternal(openapi,param.$ref);
+                }
+                delete param.required; // all true
+                delete param.type; // all strings
+                delete param.in; // all 'host'
+                if (typeof param.default === 'undefined') {
+                    if (param.enum) {
+                        param.default = param.enum[0];
+                    }
+                    else {
+                        param.default = '';
+                    }
+                }
+                server.variables[param.name] = param;
+                delete param.name;
+            }
+            openapi.servers.push(server);
+            delete openapi['x-ms-parameterized-host'];
+        }
 
-		if (!openapi.info) {
-			if (options.patch) {
-				openapi.info = {version:'',title:''};
-			}
-			else {
-				return reject(new Error('(Patchable) info object is mandatory'));
-			}
-		}
-		if ((typeof openapi.info.title === 'undefined') || (openapi.info.title === null)) {
-			if (options.patch) {
-				openapi.info.title = '';
-			}
-			else {
-				return reject(new Error('(Patchable) info.title cannot be null'));
-			}
-		}
-		if ((typeof openapi.info.version === 'undefined') || (openapi.info.version === null)) {
-			if (options.patch) {
-				openapi.info.version = '';
-			}
-			else {
-				return reject(new Error('(Patchable) info.version cannot be null'));
-			}
-		}
-		if (typeof openapi.info.version !== 'string') {
-			if (options.patch) {
-				openapi.info.version = openapi.info.version.toString();
-			}
-			else {
-				return reject(new Error('(Patchable) info.version cannot be null'));
-			}
-		}
-		if (typeof openapi.info.logo !== 'undefined') {
-			if (options.patch) {
-				openapi.info['x-logo'] = openapi.info.logo;
-				delete openapi.info.logo;
-			}
-			else return reject(new Error('(Patchable) info should not have logo property'));
-		}
-		if (typeof openapi.info.termsOfService !== 'undefined') {
-			if (openapi.info.termsOfService === null) {
-				if (options.patch) {
-					openapi.info.termsOfService = '';
-				}
-				else {
-					return reject(new Error('(Patchable) info.termsOfService cannot be null'));
-				}
-			}
-		}
+        if (!openapi.info) {
+            if (options.patch) {
+                openapi.info = {version:'',title:''};
+            }
+            else {
+                return reject(new Error('(Patchable) info object is mandatory'));
+            }
+        }
+        if ((typeof openapi.info.title === 'undefined') || (openapi.info.title === null)) {
+            if (options.patch) {
+                openapi.info.title = '';
+            }
+            else {
+                return reject(new Error('(Patchable) info.title cannot be null'));
+            }
+        }
+        if ((typeof openapi.info.version === 'undefined') || (openapi.info.version === null)) {
+            if (options.patch) {
+                openapi.info.version = '';
+            }
+            else {
+                return reject(new Error('(Patchable) info.version cannot be null'));
+            }
+        }
+        if (typeof openapi.info.version !== 'string') {
+            if (options.patch) {
+                openapi.info.version = openapi.info.version.toString();
+            }
+            else {
+                return reject(new Error('(Patchable) info.version cannot be null'));
+            }
+        }
+        if (typeof openapi.info.logo !== 'undefined') {
+            if (options.patch) {
+                openapi.info['x-logo'] = openapi.info.logo;
+                delete openapi.info.logo;
+            }
+            else return reject(new Error('(Patchable) info should not have logo property'));
+        }
+        if (typeof openapi.info.termsOfService !== 'undefined') {
+            if (openapi.info.termsOfService === null) {
+                if (options.patch) {
+                    openapi.info.termsOfService = '';
+                }
+                else {
+                    return reject(new Error('(Patchable) info.termsOfService cannot be null'));
+                }
+            }
+        }
 
-		openapi.components = {};
-		openapi.components.schemas = openapi.definitions||{};
-		openapi.components.responses = openapi.responses||{};
-		openapi.components.parameters = openapi.parameters||{};
-		openapi.components.examples = {};
-		openapi.components.requestBodies = {};
-		openapi.components.securitySchemes = openapi.securityDefinitions||{};
-		openapi.components.headers = {};
-		if (openapi['x-links']) {
-			openapi.components.links = openapi['x-links'];
-			delete openapi['x-links'];
-		}
-		if (openapi['x-callbacks']) {
-			openapi.components.callbacks = openapi['x-callbacks'];
-			delete openapi['x-callbacks'];
-		}
-		delete openapi.definitions;
-		delete openapi.responses;
-		delete openapi.parameters;
-		delete openapi.securityDefinitions;
+        openapi.components = {};
+        openapi.components.schemas = openapi.definitions||{};
+        openapi.components.responses = openapi.responses||{};
+        openapi.components.parameters = openapi.parameters||{};
+        openapi.components.examples = {};
+        openapi.components.requestBodies = {};
+        openapi.components.securitySchemes = openapi.securityDefinitions||{};
+        openapi.components.headers = {};
+        if (openapi['x-links']) {
+            openapi.components.links = openapi['x-links'];
+            delete openapi['x-links'];
+        }
+        if (openapi['x-callbacks']) {
+            openapi.components.callbacks = openapi['x-callbacks'];
+            delete openapi['x-callbacks'];
+        }
+        delete openapi.definitions;
+        delete openapi.responses;
+        delete openapi.parameters;
+        delete openapi.securityDefinitions;
 
-		var actions = [];
-		options.externals = [];
+        var actions = [];
+        options.externals = [];
 
-		if (options.resolve) {
-			common.recurse(openapi,null,function(obj,key,state){
-				if ((key === '$ref') && (typeof obj[key] === 'string')) {
-					if (!obj[key].startsWith('#/')) {
-						actions.push(common.resolveExternal(openapi,obj[key],options,function(data){
-							var external = {};
-							external.context = state.path;
-							external.$ref = obj[key];
-							external.original = common.clone(data);
-							external.updated = data;
-							options.externals.push(external);
-							state.parent[state.pkey] = data;
-						}));
-					}
-				}
-			});
-		}
+        if (options.resolve) {
+            common.recurse(openapi,null,function(obj,key,state){
+                if ((key === '$ref') && (typeof obj[key] === 'string')) {
+                    if (!obj[key].startsWith('#/')) {
+                        actions.push(common.resolveExternal(openapi,obj[key],options,function(data){
+                            var external = {};
+                            external.context = state.path;
+                            external.$ref = obj[key];
+                            external.original = common.clone(data);
+                            external.updated = data;
+                            options.externals.push(external);
+                            state.parent[state.pkey] = data;
+                        }));
+                    }
+                }
+            });
+        }
 
-		co(function* () {
-			// resolve multiple promises in parallel
-			var res = yield actions;
-			main(openapi, options);
-			if (options.direct) {
-				resolve(options.openapi);
-			}
-			else {
-				resolve(options);
-			}
-		})
-		.catch(function(err){
-			reject(err);
-		});
-	}));
+        co(function* () {
+            // resolve multiple promises in parallel
+            var res = yield actions;
+            main(openapi, options);
+            if (options.direct) {
+                resolve(options.openapi);
+            }
+            else {
+                resolve(options);
+            }
+        })
+        .catch(function(err){
+            reject(err);
+        });
+    }));
 }
 
 function convertStr(str,options,callback) {
-	return maybe(callback, new Promise(function(resolve, reject) {
-		var obj = null;
-		try {
-			obj = JSON.parse(str);
-		}
-		catch (ex) {
-			try {
-				obj = yaml.safeLoad(str,{json:true});
-				options.sourceYaml = true;
-			}
-			catch (ex) {}
-		}
-		if (obj) {
-			return convertObj(obj,options,callback)
-		}
-		else {
-			reject(new Error('Could not resolve url'));
-		}
-	}));
+    return maybe(callback, new Promise(function(resolve, reject) {
+        var obj = null;
+        try {
+            obj = JSON.parse(str);
+        }
+        catch (ex) {
+            try {
+                obj = yaml.safeLoad(str,{json:true});
+                options.sourceYaml = true;
+            }
+            catch (ex) {}
+        }
+        if (obj) {
+            return convertObj(obj,options,callback)
+        }
+        else {
+            reject(new Error('Could not resolve url'));
+        }
+    }));
 }
 
 function convertUrl(url,options,callback) {
-	return maybe(callback, new Promise(function(resolve, reject) {
-		if (!options.origin) {
-			options.origin = url;
-		}
-		if (options.verbose) {
-			console.log('GET '+url);
-		}
-		fetch(url).then(function(res) {
-			return res.text();
-		}).then(function(body) {
-			return convertStr(body,options,callback);
-		}).catch(function(err){
-			reject(err);
-		});
-	}));
+    return maybe(callback, new Promise(function(resolve, reject) {
+        if (!options.origin) {
+            options.origin = url;
+        }
+        if (options.verbose) {
+            console.log('GET '+url);
+        }
+        fetch(url).then(function(res) {
+            return res.text();
+        }).then(function(body) {
+            return convertStr(body,options,callback);
+        }).catch(function(err){
+            reject(err);
+        });
+    }));
 }
 
 function convertFile(filename,options,callback) {
-	return maybe(callback, new Promise(function(resolve, reject) {
-		fs.readFile(filename,options.encoding||'utf8',function(err,s){
-			if (err) {
-				reject(err);
-			}
-			else {
-				options.sourceFile = filename;
-				return convertStr(s,options,callback)
-			}
-		});
-	}));
+    return maybe(callback, new Promise(function(resolve, reject) {
+        fs.readFile(filename,options.encoding||'utf8',function(err,s){
+            if (err) {
+                reject(err);
+            }
+            else {
+                options.sourceFile = filename;
+                return convertStr(s,options,callback)
+            }
+        });
+    }));
 }
 
 function convertStream(readable,options,callback) {
-	return maybe(callback, new Promise(function(resolve, reject) {
-		var data = '';
-		readable.on('data',function(chunk){
-			data += chunk;
-		})
-		.on('end',function(){
-			return convertStr(data,options,callback);
-		});
-	}));
+    return maybe(callback, new Promise(function(resolve, reject) {
+        var data = '';
+        readable.on('data',function(chunk){
+            data += chunk;
+        })
+        .on('end',function(){
+            return convertStr(data,options,callback);
+        });
+    }));
 }
 
 module.exports = {
 
-	targetVersion : targetVersion,
+    targetVersion : targetVersion,
     convert : convertObj,
-	convertObj : convertObj,
-	convertUrl : convertUrl,
-	convertStr : convertStr,
-	convertFile : convertFile,
-	convertStream : convertStream
+    convertObj : convertObj,
+    convertUrl : convertUrl,
+    convertStr : convertStr,
+    convertFile : convertFile,
+    convertStream : convertStream
 
 };

--- a/schemas/gnostic-3.0.json
+++ b/schemas/gnostic-3.0.json
@@ -1,1322 +1,1322 @@
 {
-  "title": "A JSON Schema for OpenAPI 3.0.",
-  "id": "http://openapis.org/v3/schema.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "description": "This is the root document object for the API specification. It combines what previously was the Resource Listing and API Declaration (version 1.2 and earlier) together into one document.",
-  "required": [
-    "openapi",
-    "info",
-    "paths"
-  ],
-  "additionalProperties": false,
-  "patternProperties": {
-    "^x-": {
-      "$ref": "#/definitions/specificationExtension"
-    }
-  },
-  "properties": {
-    "openapi": {
-      "type": "string"
-    },
-    "info": {
-      "$ref": "#/definitions/info"
-    },
-    "servers": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/server"
-      },
-      "uniqueItems": true
-    },
-    "paths": {
-      "$ref": "#/definitions/paths"
-    },
-    "components": {
-      "$ref": "#/definitions/components"
-    },
-    "security": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/securityRequirement"
-      },
-      "uniqueItems": true
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/tag"
-      },
-      "uniqueItems": true
-    },
-    "externalDocs": {
-      "$ref": "#/definitions/externalDocs"
-    }
-  },
-  "definitions": {
-    "info": {
-      "type": "object",
-      "description": "The object provides metadata about the API. The metadata can be used by the clients if needed, and can be presented in editing or documentation generation tools for convenience.",
-      "required": [
-        "title",
-        "version"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
+    "title": "A JSON Schema for OpenAPI 3.0.",
+    "id": "http://openapis.org/v3/schema.json#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "This is the root document object for the API specification. It combines what previously was the Resource Listing and API Declaration (version 1.2 and earlier) together into one document.",
+    "required": [
+        "openapi",
+        "info",
+        "paths"
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
         "^x-": {
-          "$ref": "#/definitions/specificationExtension"
+            "$ref": "#/definitions/specificationExtension"
         }
-      },
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "termsOfService": {
-          "type": "string"
-        },
-        "contact": {
-          "$ref": "#/definitions/contact"
-        },
-        "license": {
-          "$ref": "#/definitions/license"
-        },
-        "version": {
-          "type": "string"
-        }
-      }
     },
-    "contact": {
-      "type": "object",
-      "description": "Contact information for the exposed API.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        }
-      }
-    },
-    "license": {
-      "type": "object",
-      "description": "License information for the exposed API.",
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        }
-      }
-    },
-    "server": {
-      "type": "object",
-      "description": "An object representing a Server.",
-      "required": [
-        "url"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "url": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "variables": {
-          "$ref": "#/definitions/serverVariables"
-        }
-      }
-    },
-    "serverVariables": {
-      "type": "object",
-      "description": "",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/definitions/serverVariable"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "serverVariable": {
-      "type": "object",
-      "description": "An object representing a Server Variable for server URL template substitution.",
-      "required": [
-        "default"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "enum": {
-          "type": "array",
-          "items": {
+    "properties": {
+        "openapi": {
             "type": "string"
-          },
-          "uniqueItems": true
         },
-        "default": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    },
-    "components": {
-      "type": "object",
-      "description": "Holds a set of reusable objects for different aspects of the OAS. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "schemas": {
-          "$ref": "#/definitions/schemasOrReferences"
-        },
-        "responses": {
-          "$ref": "#/definitions/responsesOrReferences"
-        },
-        "parameters": {
-          "$ref": "#/definitions/parametersOrReferences"
-        },
-        "examples": {
-          "$ref": "#/definitions/examplesOrReferences"
-        },
-        "requestBodies": {
-          "$ref": "#/definitions/requestBodiesOrReferences"
-        },
-        "headers": {
-          "$ref": "#/definitions/headersOrReferences"
-        },
-        "securitySchemes": {
-          "$ref": "#/definitions/securitySchemesOrReferences"
-        },
-        "links": {
-          "$ref": "#/definitions/linksOrReferences"
-        },
-        "callbacks": {
-          "$ref": "#/definitions/callbacksOrReferences"
-        }
-      }
-    },
-    "paths": {
-      "type": "object",
-      "description": "Holds the relative paths to the individual endpoints and their operations. The path is appended to the URL from the `Server Object` in order to construct the full URL.  The Paths MAY be empty, due to ACL constraints.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^/": {
-          "$ref": "#/definitions/pathItem"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "pathItem": {
-      "type": "object",
-      "description": "Describes the operations available on a single path. A Path Item MAY be empty, due to ACL constraints. The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "$ref": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "get": {
-          "$ref": "#/definitions/operation"
-        },
-        "put": {
-          "$ref": "#/definitions/operation"
-        },
-        "post": {
-          "$ref": "#/definitions/operation"
-        },
-        "delete": {
-          "$ref": "#/definitions/operation"
-        },
-        "options": {
-          "$ref": "#/definitions/operation"
-        },
-        "head": {
-          "$ref": "#/definitions/operation"
-        },
-        "patch": {
-          "$ref": "#/definitions/operation"
-        },
-        "trace": {
-          "$ref": "#/definitions/operation"
+        "info": {
+            "$ref": "#/definitions/info"
         },
         "servers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/server"
-          },
-          "uniqueItems": true
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/server"
+            },
+            "uniqueItems": true
         },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/parameterOrReference"
-          },
-          "uniqueItems": true
-        }
-      }
-    },
-    "operation": {
-      "type": "object",
-      "description": "Describes a single API operation on a path.",
-      "required": [
-        "responses"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
+        "paths": {
+            "$ref": "#/definitions/paths"
         },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        },
-        "operationId": {
-          "type": "string"
-        },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/parameterOrReference"
-          },
-          "uniqueItems": true
-        },
-        "requestBody": {
-          "$ref": "#/definitions/requestBodyOrReference"
-        },
-        "responses": {
-          "$ref": "#/definitions/responses"
-        },
-        "callbacks": {
-          "$ref": "#/definitions/callbacks"
-        },
-        "deprecated": {
-          "type": "boolean"
+        "components": {
+            "$ref": "#/definitions/components"
         },
         "security": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/securityRequirement"
-          },
-          "uniqueItems": true
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/securityRequirement"
+            },
+            "uniqueItems": true
         },
-        "servers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/server"
-          },
-          "uniqueItems": true
+        "tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/tag"
+            },
+            "uniqueItems": true
+        },
+        "externalDocs": {
+            "$ref": "#/definitions/externalDocs"
         }
-      }
     },
-    "externalDocs": {
-      "type": "object",
-      "description": "Allows referencing an external resource for extended documentation.",
-      "required": [
-        "url"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "description": {
-          "type": "string"
+    "definitions": {
+        "info": {
+            "type": "object",
+            "description": "The object provides metadata about the API. The metadata can be used by the clients if needed, and can be presented in editing or documentation generation tools for convenience.",
+            "required": [
+                "title",
+                "version"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "termsOfService": {
+                    "type": "string"
+                },
+                "contact": {
+                    "$ref": "#/definitions/contact"
+                },
+                "license": {
+                    "$ref": "#/definitions/license"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
         },
-        "url": {
-          "type": "string"
-        }
-      }
-    },
-    "parameter": {
-      "type": "object",
-      "description": "Describes a single operation parameter.  A unique parameter is defined by a combination of a name and location.",
-      "required": [
-        "name",
-        "in"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
+        "contact": {
+            "type": "object",
+            "description": "Contact information for the exposed API.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                }
+            }
         },
-        "in": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "deprecated": {
-          "type": "boolean"
-        },
-        "allowEmptyValue": {
-          "type": "boolean"
-        },
-        "style": {
-          "type": "string"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean"
-        },
-        "schema": {
-          "$ref": "#/definitions/schemaOrReference"
-        },
-        "example": {
-          "$ref": "#/definitions/any"
-        },
-        "examples": {
-          "$ref": "#/definitions/examplesOrReferences"
-        },
-        "content": {
-          "$ref": "#/definitions/content"
-        }
-      }
-    },
-    "requestBody": {
-      "type": "object",
-      "description": "Describes a single request body.",
-      "required": [
-        "content"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "content": {
-          "$ref": "#/definitions/content"
-        },
-        "required": {
-          "type": "boolean"
-        }
-      }
-    },
-    "content": {
-      "type": "object",
-      "description": "Describes a set of supported media types. A Content Object can be used in Request Body Object, Parameter Objects, Header Objects, and Response Objects.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^": {
-          "$ref": "#/definitions/mediaType"
-        }
-      }
-    },
-    "mediaType": {
-      "type": "object",
-      "description": "Each Media Type Object provides schema and examples for a the media type identified by its key.  Media Type Objects can be used in a Content Object.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "schema": {
-          "$ref": "#/definitions/schemaOrReference"
-        },
-        "example": {
-          "$ref": "#/definitions/any"
-        },
-        "examples": {
-          "$ref": "#/definitions/examplesOrReferences"
-        },
-        "encoding": {
-          "$ref": "#/definitions/encoding"
-        }
-      }
-    },
-    "encoding": {
-      "type": "object",
-      "description": "An object representing multipart region encoding for `requestBody` objects.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^": {
-          "$ref": "#/definitions/encodingProperty"
-        }
-      }
-    },
-    "encodingProperty": {
-      "type": "object",
-      "description": "A single encoding definition applied to a single schema property.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "contentType": {
-          "type": "string"
-        },
-        "headers": {
-          "$ref": "#/definitions/headersMap"
-        },
-        "style": {
-          "type": "string"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean"
-        }
-      }
-    },
-    "responses": {
-      "type": "object",
-      "description": "A container for the expected responses of an operation. The container maps a HTTP response code to the expected response.  It is not expected for the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected for the documentation to cover a successful operation response and any known errors.  The `default` MAY be used as a default response object for all HTTP codes  that are not covered individually by the specification.  The `Responses Object` MUST contain at least one response code, and it  SHOULD be the response for a successful operation call.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^([0-9X]{3})$": {
-          "$ref": "#/definitions/responseOrReference"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "default": {
-          "$ref": "#/definitions/responseOrReference"
-        }
-      }
-    },
-    "response": {
-      "type": "object",
-      "description": "Describes a single response from an API Operation, including design-time, static  `links` to operations based on the response.",
-      "required": [
-        "description"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "headers": {
-          "$ref": "#/definitions/headers"
-        },
-        "content": {
-          "$ref": "#/definitions/content"
-        },
-        "links": {
-          "$ref": "#/definitions/links"
-        }
-      }
-    },
-    "callbacks": {
-      "type": "object",
-      "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Callback Object that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/definitions/callbackOrReference"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "callback": {
-      "type": "object",
-      "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Path Item Object that describes a set of requests that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^": {
-          "$ref": "#/definitions/pathItem"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "headers": {
-      "type": "object",
-      "description": "Lists the headers that can be sent in a response or forwarded via a link. Note that RFC7230 states header names are case insensitive.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/definitions/headerOrReference"
-        }
-      }
-    },
-    "example": {
-      "type": "object",
-      "description": "",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/definitions/any"
-        },
-        "externalValue": {
-          "type": "string"
-        }
-      }
-    },
-    "links": {
-      "type": "object",
-      "description": "The links object represents a set of possible design-time links for a response. The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.  As opposed to _dynamic_ links (links provided **in** the response payload), the OAS linking mechanism does not require that link information be provided in a specific response format at runtime.  For computing links, and providing instructions to execute them, variable substitution is used for accessing values in a response and using them as values while invoking the linked operation.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/definitions/linkOrReference"
-        }
-      }
-    },
-    "link": {
-      "type": "object",
-      "description": "The `Link Object` is responsible for defining a possible operation based on a single response.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "operationRef": {
-          "type": "string"
-        },
-        "operationId": {
-          "type": "string"
-        },
-        "parameters": {
-          "$ref": "#/definitions/linkParameters"
-        },
-        "headers": {
-          "$ref": "#/definitions/headers"
-        },
-        "description": {
-          "type": "string"
+        "license": {
+            "type": "object",
+            "description": "License information for the exposed API.",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
         },
         "server": {
-          "$ref": "#/definitions/server"
-        }
-      }
-    },
-    "linkParameters": {
-      "type": "object",
-      "description": "Using the `operationId` to reference an operation in the definition has many benefits, including the ability to define media type options, security requirements, response and error payloads. Many operations require parameters to be passed, and these MAY be dynamic depending on the response itself.  To specify parameters required by the operation, we can use a **Link Parameters Object**. This object contains parameter names along with static or dynamic values:",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "$ref": "#/definitions/anyOrExpression"
-        }
-      }
-    },
-    "header": {
-      "type": "object",
-      "description": "The Header Object follows the structure of the Parameter Object, with the following changes:  1. `name` MUST NOT be specified, it is given in the Headers Object. 1. `in` MUST NOT be specified, it is implicitly in `header`. 1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, `style`).",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
+            "type": "object",
+            "description": "An object representing a Server.",
+            "required": [
+                "url"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "variables": {
+                    "$ref": "#/definitions/serverVariables"
+                }
+            }
         },
-        "in": {
-          "type": "string"
+        "serverVariables": {
+            "type": "object",
+            "description": "",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/definitions/serverVariable"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            }
         },
-        "description": {
-          "type": "string"
+        "serverVariable": {
+            "type": "object",
+            "description": "An object representing a Server Variable for server URL template substitution.",
+            "required": [
+                "default"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            }
         },
-        "required": {
-          "type": "boolean"
+        "components": {
+            "type": "object",
+            "description": "Holds a set of reusable objects for different aspects of the OAS. All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "schemas": {
+                    "$ref": "#/definitions/schemasOrReferences"
+                },
+                "responses": {
+                    "$ref": "#/definitions/responsesOrReferences"
+                },
+                "parameters": {
+                    "$ref": "#/definitions/parametersOrReferences"
+                },
+                "examples": {
+                    "$ref": "#/definitions/examplesOrReferences"
+                },
+                "requestBodies": {
+                    "$ref": "#/definitions/requestBodiesOrReferences"
+                },
+                "headers": {
+                    "$ref": "#/definitions/headersOrReferences"
+                },
+                "securitySchemes": {
+                    "$ref": "#/definitions/securitySchemesOrReferences"
+                },
+                "links": {
+                    "$ref": "#/definitions/linksOrReferences"
+                },
+                "callbacks": {
+                    "$ref": "#/definitions/callbacksOrReferences"
+                }
+            }
         },
-        "deprecated": {
-          "type": "boolean"
+        "paths": {
+            "type": "object",
+            "description": "Holds the relative paths to the individual endpoints and their operations. The path is appended to the URL from the `Server Object` in order to construct the full URL.  The Paths MAY be empty, due to ACL constraints.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^/": {
+                    "$ref": "#/definitions/pathItem"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            }
         },
-        "allowEmptyValue": {
-          "type": "boolean"
+        "pathItem": {
+            "type": "object",
+            "description": "Describes the operations available on a single path. A Path Item MAY be empty, due to ACL constraints. The path itself is still exposed to the documentation viewer but they will not know which operations and parameters are available.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "$ref": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "get": {
+                    "$ref": "#/definitions/operation"
+                },
+                "put": {
+                    "$ref": "#/definitions/operation"
+                },
+                "post": {
+                    "$ref": "#/definitions/operation"
+                },
+                "delete": {
+                    "$ref": "#/definitions/operation"
+                },
+                "options": {
+                    "$ref": "#/definitions/operation"
+                },
+                "head": {
+                    "$ref": "#/definitions/operation"
+                },
+                "patch": {
+                    "$ref": "#/definitions/operation"
+                },
+                "trace": {
+                    "$ref": "#/definitions/operation"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/server"
+                    },
+                    "uniqueItems": true
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/parameterOrReference"
+                    },
+                    "uniqueItems": true
+                }
+            }
         },
-        "style": {
-          "type": "string"
+        "operation": {
+            "type": "object",
+            "description": "Describes a single API operation on a path.",
+            "required": [
+                "responses"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/externalDocs"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/parameterOrReference"
+                    },
+                    "uniqueItems": true
+                },
+                "requestBody": {
+                    "$ref": "#/definitions/requestBodyOrReference"
+                },
+                "responses": {
+                    "$ref": "#/definitions/responses"
+                },
+                "callbacks": {
+                    "$ref": "#/definitions/callbacks"
+                },
+                "deprecated": {
+                    "type": "boolean"
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/securityRequirement"
+                    },
+                    "uniqueItems": true
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/server"
+                    },
+                    "uniqueItems": true
+                }
+            }
         },
-        "explode": {
-          "type": "boolean"
+        "externalDocs": {
+            "type": "object",
+            "description": "Allows referencing an external resource for extended documentation.",
+            "required": [
+                "url"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
         },
-        "allowReserved": {
-          "type": "boolean"
+        "parameter": {
+            "type": "object",
+            "description": "Describes a single operation parameter.  A unique parameter is defined by a combination of a name and location.",
+            "required": [
+                "name",
+                "in"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "deprecated": {
+                    "type": "boolean"
+                },
+                "allowEmptyValue": {
+                    "type": "boolean"
+                },
+                "style": {
+                    "type": "string"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean"
+                },
+                "schema": {
+                    "$ref": "#/definitions/schemaOrReference"
+                },
+                "example": {
+                    "$ref": "#/definitions/any"
+                },
+                "examples": {
+                    "$ref": "#/definitions/examplesOrReferences"
+                },
+                "content": {
+                    "$ref": "#/definitions/content"
+                }
+            }
         },
-        "schema": {
-          "$ref": "#/definitions/schemaOrReference"
-        },
-        "example": {
-          "$ref": "#/definitions/any"
-        },
-        "examples": {
-          "$ref": "#/definitions/examplesOrReferences"
+        "requestBody": {
+            "type": "object",
+            "description": "Describes a single request body.",
+            "required": [
+                "content"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "content": {
+                    "$ref": "#/definitions/content"
+                },
+                "required": {
+                    "type": "boolean"
+                }
+            }
         },
         "content": {
-          "$ref": "#/definitions/content"
-        }
-      }
-    },
-    "tag": {
-      "type": "object",
-      "description": "Allows adding meta data to a single tag that is used by the Operation Object. It is not mandatory to have a Tag Object per tag used there.",
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
+            "type": "object",
+            "description": "Describes a set of supported media types. A Content Object can be used in Request Body Object, Parameter Objects, Header Objects, and Response Objects.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^": {
+                    "$ref": "#/definitions/mediaType"
+                }
+            }
         },
-        "description": {
-          "type": "string"
+        "mediaType": {
+            "type": "object",
+            "description": "Each Media Type Object provides schema and examples for a the media type identified by its key.  Media Type Objects can be used in a Content Object.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "schema": {
+                    "$ref": "#/definitions/schemaOrReference"
+                },
+                "example": {
+                    "$ref": "#/definitions/any"
+                },
+                "examples": {
+                    "$ref": "#/definitions/examplesOrReferences"
+                },
+                "encoding": {
+                    "$ref": "#/definitions/encoding"
+                }
+            }
         },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
-        }
-      }
-    },
-    "examples": {
-      "type": "object",
-      "description": "",
-      "additionalProperties": false
-    },
-    "reference": {
-      "type": "object",
-      "description": "A simple object to allow referencing other components in the specification, internally and externally.  The Reference Object is defined by JSON Reference and follows the same structure, behavior and rules.   For this specification, reference resolution is done as defined by the JSON Reference specification and not by the JSON Schema specification.",
-      "required": [
-        "$ref"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "$ref": {
-          "type": "string"
-        }
-      }
-    },
-    "schema": {
-      "type": "object",
-      "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  Further information about the properties can be found in JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "nullable": {
-          "type": "boolean"
+        "encoding": {
+            "type": "object",
+            "description": "An object representing multipart region encoding for `requestBody` objects.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^": {
+                    "$ref": "#/definitions/encodingProperty"
+                }
+            }
         },
-        "discriminator": {
-          "$ref": "#/definitions/discriminator"
+        "encodingProperty": {
+            "type": "object",
+            "description": "A single encoding definition applied to a single schema property.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "#/definitions/headersMap"
+                },
+                "style": {
+                    "type": "string"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean"
+                }
+            }
         },
-        "readOnly": {
-          "type": "boolean"
+        "responses": {
+            "type": "object",
+            "description": "A container for the expected responses of an operation. The container maps a HTTP response code to the expected response.  It is not expected for the documentation to necessarily cover all possible HTTP response codes, since they may not be known in advance. However, it is expected for the documentation to cover a successful operation response and any known errors.  The `default` MAY be used as a default response object for all HTTP codes  that are not covered individually by the specification.  The `Responses Object` MUST contain at least one response code, and it  SHOULD be the response for a successful operation call.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([0-9X]{3})$": {
+                    "$ref": "#/definitions/responseOrReference"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "default": {
+                    "$ref": "#/definitions/responseOrReference"
+                }
+            }
         },
-        "writeOnly": {
-          "type": "boolean"
+        "response": {
+            "type": "object",
+            "description": "Describes a single response from an API Operation, including design-time, static  `links` to operations based on the response.",
+            "required": [
+                "description"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "#/definitions/headers"
+                },
+                "content": {
+                    "$ref": "#/definitions/content"
+                },
+                "links": {
+                    "$ref": "#/definitions/links"
+                }
+            }
         },
-        "xml": {
-          "$ref": "#/definitions/xml"
+        "callbacks": {
+            "type": "object",
+            "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Callback Object that describes a request that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/definitions/callbackOrReference"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            }
         },
-        "externalDocs": {
-          "$ref": "#/definitions/externalDocs"
+        "callback": {
+            "type": "object",
+            "description": "A map of possible out-of band callbacks related to the parent operation. Each value in the map is a Path Item Object that describes a set of requests that may be initiated by the API provider and the expected responses. The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^": {
+                    "$ref": "#/definitions/pathItem"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            }
+        },
+        "headers": {
+            "type": "object",
+            "description": "Lists the headers that can be sent in a response or forwarded via a link. Note that RFC7230 states header names are case insensitive.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/definitions/headerOrReference"
+                }
+            }
         },
         "example": {
-          "$ref": "#/definitions/any"
-        },
-        "deprecated": {
-          "type": "boolean"
-        },
-        "title": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
-        },
-        "multipleOf": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
-        },
-        "maximum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
-        },
-        "exclusiveMaximum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
-        },
-        "minimum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
-        },
-        "exclusiveMinimum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
-        },
-        "maxLength": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxLength"
-        },
-        "minLength": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minLength"
-        },
-        "pattern": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
-        },
-        "maxItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxItems"
-        },
-        "minItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minItems"
-        },
-        "uniqueItems": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
-        },
-        "maxProperties": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/maxProperties"
-        },
-        "minProperties": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/minProperties"
-        },
-        "required": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/required"
-        },
-        "enum": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
-        },
-        "type": {
-          "type": "string"
-        },
-        "allOf": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/schemaOrReference"
-          },
-          "minItems": 1
-        },
-        "oneOf": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/schemaOrReference"
-          },
-          "minItems": 1
-        },
-        "anyOf": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/schemaOrReference"
-          },
-          "minItems": 1
-        },
-        "not": {
-          "$ref": "#/definitions/schema"
-        },
-        "items": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/schemaOrReference"
+            "type": "object",
+            "description": "",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
             },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/schemaOrReference"
-              },
-              "minItems": 1
+            "properties": {
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/any"
+                },
+                "externalValue": {
+                    "type": "string"
+                }
             }
-          ]
         },
-        "properties": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/schemaOrReference"
-          }
+        "links": {
+            "type": "object",
+            "description": "The links object represents a set of possible design-time links for a response. The presence of a link does not guarantee the caller's ability to successfully invoke it, rather it provides a known relationship and traversal mechanism between responses and other operations.  As opposed to _dynamic_ links (links provided **in** the response payload), the OAS linking mechanism does not require that link information be provided in a specific response format at runtime.  For computing links, and providing instructions to execute them, variable substitution is used for accessing values in a response and using them as values while invoking the linked operation.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/definitions/linkOrReference"
+                }
+            }
         },
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/schemaOrReference"
+        "link": {
+            "type": "object",
+            "description": "The `Link Object` is responsible for defining a possible operation based on a single response.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
             },
-            {
-              "type": "boolean"
+            "properties": {
+                "operationRef": {
+                    "type": "string"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "$ref": "#/definitions/linkParameters"
+                },
+                "headers": {
+                    "$ref": "#/definitions/headers"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "server": {
+                    "$ref": "#/definitions/server"
+                }
             }
-          ]
         },
-        "default": {
-          "$ref": "#/definitions/defaultType"
+        "linkParameters": {
+            "type": "object",
+            "description": "Using the `operationId` to reference an operation in the definition has many benefits, including the ability to define media type options, security requirements, response and error payloads. Many operations require parameters to be passed, and these MAY be dynamic depending on the response itself.  To specify parameters required by the operation, we can use a **Link Parameters Object**. This object contains parameter names along with static or dynamic values:",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "$ref": "#/definitions/anyOrExpression"
+                }
+            }
         },
-        "description": {
-          "type": "string"
+        "header": {
+            "type": "object",
+            "description": "The Header Object follows the structure of the Parameter Object, with the following changes:  1. `name` MUST NOT be specified, it is given in the Headers Object. 1. `in` MUST NOT be specified, it is implicitly in `header`. 1. All traits that are affected by the location MUST be applicable to a location of `header` (for example, `style`).",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "deprecated": {
+                    "type": "boolean"
+                },
+                "allowEmptyValue": {
+                    "type": "boolean"
+                },
+                "style": {
+                    "type": "string"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean"
+                },
+                "schema": {
+                    "$ref": "#/definitions/schemaOrReference"
+                },
+                "example": {
+                    "$ref": "#/definitions/any"
+                },
+                "examples": {
+                    "$ref": "#/definitions/examplesOrReferences"
+                },
+                "content": {
+                    "$ref": "#/definitions/content"
+                }
+            }
         },
-        "format": {
-          "type": "string"
-        }
-      }
-    },
-    "discriminator": {
-      "type": "object",
-      "description": "When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.  Note, when using the discriminator, _inline_ schemas will not be considered when using the discriminator.",
-      "additionalProperties": false,
-      "properties": {
-        "propertyName": {
-          "type": "string"
+        "tag": {
+            "type": "object",
+            "description": "Allows adding meta data to a single tag that is used by the Operation Object. It is not mandatory to have a Tag Object per tag used there.",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/externalDocs"
+                }
+            }
         },
-        "mapping": {
-          "$ref": "#/definitions/strings"
-        }
-      }
-    },
-    "xml": {
-      "type": "object",
-      "description": "A metadata object that allows for more fine-tuned XML model definitions.  When using arrays, XML element names are *not* inferred (for singular/plural forms) and the `name` property SHOULD be used to add that information. See examples for expected behavior.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "name": {
-          "type": "string"
+        "examples": {
+            "type": "object",
+            "description": "",
+            "additionalProperties": false
         },
-        "namespace": {
-          "type": "string"
+        "reference": {
+            "type": "object",
+            "description": "A simple object to allow referencing other components in the specification, internally and externally.  The Reference Object is defined by JSON Reference and follows the same structure, behavior and rules.   For this specification, reference resolution is done as defined by the JSON Reference specification and not by the JSON Schema specification.",
+            "required": [
+                "$ref"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "$ref": {
+                    "type": "string"
+                }
+            }
         },
-        "prefix": {
-          "type": "string"
+        "schema": {
+            "type": "object",
+            "description": "The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  Further information about the properties can be found in JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "nullable": {
+                    "type": "boolean"
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean"
+                },
+                "writeOnly": {
+                    "type": "boolean"
+                },
+                "xml": {
+                    "$ref": "#/definitions/xml"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/externalDocs"
+                },
+                "example": {
+                    "$ref": "#/definitions/any"
+                },
+                "deprecated": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                },
+                "multipleOf": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                },
+                "maximum": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                },
+                "exclusiveMaximum": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                },
+                "minimum": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                },
+                "exclusiveMinimum": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                },
+                "maxLength": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maxLength"
+                },
+                "minLength": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minLength"
+                },
+                "pattern": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                },
+                "maxItems": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maxItems"
+                },
+                "minItems": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minItems"
+                },
+                "uniqueItems": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                },
+                "maxProperties": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maxProperties"
+                },
+                "minProperties": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minProperties"
+                },
+                "required": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/required"
+                },
+                "enum": {
+                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/schemaOrReference"
+                    },
+                    "minItems": 1
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/schemaOrReference"
+                    },
+                    "minItems": 1
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/schemaOrReference"
+                    },
+                    "minItems": 1
+                },
+                "not": {
+                    "$ref": "#/definitions/schema"
+                },
+                "items": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/schemaOrReference"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/schemaOrReference"
+                            },
+                            "minItems": 1
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/schemaOrReference"
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/schemaOrReference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                "default": {
+                    "$ref": "#/definitions/defaultType"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                }
+            }
         },
-        "attribute": {
-          "type": "boolean"
+        "discriminator": {
+            "type": "object",
+            "description": "When request bodies or response payloads may be one of a number of different schemas, a `discriminator` object can be used to aid in serialization, deserialization, and validation.  The discriminator is a specific object in a schema which is used to inform the consumer of the specification of an alternative schema based on the value associated with it.  Note, when using the discriminator, _inline_ schemas will not be considered when using the discriminator.",
+            "additionalProperties": false,
+            "properties": {
+                "propertyName": {
+                    "type": "string"
+                },
+                "mapping": {
+                    "$ref": "#/definitions/strings"
+                }
+            }
         },
-        "wrapped": {
-          "type": "boolean"
-        }
-      }
-    },
-    "securityScheme": {
-      "type": "object",
-      "description": "Allows the definition of a security scheme that can be used by the operations. Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter) and OAuth2's common flows (implicit, password, application and access code).",
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "type": {
-          "type": "string"
+        "xml": {
+            "type": "object",
+            "description": "A metadata object that allows for more fine-tuned XML model definitions.  When using arrays, XML element names are *not* inferred (for singular/plural forms) and the `name` property SHOULD be used to add that information. See examples for expected behavior.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "attribute": {
+                    "type": "boolean"
+                },
+                "wrapped": {
+                    "type": "boolean"
+                }
+            }
         },
-        "description": {
-          "type": "string"
+        "securityScheme": {
+            "type": "object",
+            "description": "Allows the definition of a security scheme that can be used by the operations. Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter) and OAuth2's common flows (implicit, password, application and access code).",
+            "required": [
+                "type"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string"
+                },
+                "scheme": {
+                    "type": "string"
+                },
+                "bearerFormat": {
+                    "type": "string"
+                },
+                "flows": {
+                    "$ref": "#/definitions/oauthFlows"
+                },
+                "openIdConnectUrl": {
+                    "type": "string"
+                }
+            }
         },
-        "name": {
-          "type": "string"
+        "oauthFlows": {
+            "type": "object",
+            "description": "Allows configuration of the supported OAuth Flows.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "implicit": {
+                    "$ref": "#/definitions/oauthFlow"
+                },
+                "password": {
+                    "$ref": "#/definitions/oauthFlow"
+                },
+                "clientCredentials": {
+                    "$ref": "#/definitions/oauthFlow"
+                },
+                "authorizationCode": {
+                    "$ref": "#/definitions/oauthFlow"
+                }
+            }
         },
-        "in": {
-          "type": "string"
-        },
-        "scheme": {
-          "type": "string"
-        },
-        "bearerFormat": {
-          "type": "string"
-        },
-        "flows": {
-          "$ref": "#/definitions/oauthFlows"
-        },
-        "openIdConnectUrl": {
-          "type": "string"
-        }
-      }
-    },
-    "oauthFlows": {
-      "type": "object",
-      "description": "Allows configuration of the supported OAuth Flows.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "implicit": {
-          "$ref": "#/definitions/oauthFlow"
-        },
-        "password": {
-          "$ref": "#/definitions/oauthFlow"
-        },
-        "clientCredentials": {
-          "$ref": "#/definitions/oauthFlow"
-        },
-        "authorizationCode": {
-          "$ref": "#/definitions/oauthFlow"
-        }
-      }
-    },
-    "oauthFlow": {
-      "type": "object",
-      "description": "Configuration details for a supported OAuth Flow",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      },
-      "properties": {
-        "authorizationUrl": {
-          "type": "string"
-        },
-        "tokenUrl": {
-          "type": "string"
-        },
-        "refreshUrl": {
-          "type": "string"
+        "oauthFlow": {
+            "type": "object",
+            "description": "Configuration details for a supported OAuth Flow",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            },
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string"
+                },
+                "tokenUrl": {
+                    "type": "string"
+                },
+                "refreshUrl": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "$ref": "#/definitions/scopes"
+                }
+            }
         },
         "scopes": {
-          "$ref": "#/definitions/scopes"
+            "type": "object",
+            "description": "Lists the available scopes for an OAuth2 security scheme.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^": {
+                    "type": "string"
+                },
+                "^x-": {
+                    "$ref": "#/definitions/specificationExtension"
+                }
+            }
+        },
+        "securityRequirement": {
+            "type": "object",
+            "description": "Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.  Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized. This enables support for scenarios where there multiple query parameters or HTTP headers are required to convey security information.  When a list of Security Requirement Objects is defined on the Open API object or Operation Object, only one of Security Requirement Objects in the list needs to be satisfied to authorize.",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^[a-zA-Z0-9\\.\\-_]+$": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            }
+        },
+        "anyOrExpression": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/any"
+                },
+                {
+                    "$ref": "#/definitions/expression"
+                }
+            ]
+        },
+        "callbackOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/callback"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "exampleOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/example"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "headerOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/header"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "linkOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/link"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "parameterOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/parameter"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "requestBodyOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/requestBody"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "responseOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/response"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "schemaOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/schema"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "securitySchemeOrReference": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/securityScheme"
+                },
+                {
+                    "$ref": "#/definitions/reference"
+                }
+            ]
+        },
+        "callbacksOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/callbackOrReference"
+            }
+        },
+        "examplesOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/exampleOrReference"
+            }
+        },
+        "headersMap": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/header"
+            }
+        },
+        "headersOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/headerOrReference"
+            }
+        },
+        "linksOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/linkOrReference"
+            }
+        },
+        "parametersOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/parameterOrReference"
+            }
+        },
+        "requestBodiesOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/requestBodyOrReference"
+            }
+        },
+        "responsesOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/responseOrReference"
+            }
+        },
+        "schemasOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/schemaOrReference"
+            }
+        },
+        "securitySchemesOrReferences": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/securitySchemeOrReference"
+            }
+        },
+        "strings": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "object": {
+            "type": "object",
+            "additionalProperties": true
+        },
+        "any": {
+            "additionalProperties": true
+        },
+        "expression": {
+            "type": "object",
+            "additionalProperties": true
+        },
+        "specificationExtension": {
+            "description": "Any property starting with x- is valid.",
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "defaultType": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "array"
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
-      }
-    },
-    "scopes": {
-      "type": "object",
-      "description": "Lists the available scopes for an OAuth2 security scheme.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^": {
-          "type": "string"
-        },
-        "^x-": {
-          "$ref": "#/definitions/specificationExtension"
-        }
-      }
-    },
-    "securityRequirement": {
-      "type": "object",
-      "description": "Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.  Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized. This enables support for scenarios where there multiple query parameters or HTTP headers are required to convey security information.  When a list of Security Requirement Objects is defined on the Open API object or Operation Object, only one of Security Requirement Objects in the list needs to be satisfied to authorize.",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-zA-Z0-9\\.\\-_]+$": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        }
-      }
-    },
-    "anyOrExpression": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/any"
-        },
-        {
-          "$ref": "#/definitions/expression"
-        }
-      ]
-    },
-    "callbackOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/callback"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "exampleOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/example"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "headerOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/header"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "linkOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/link"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "parameterOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/parameter"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "requestBodyOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/requestBody"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "responseOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/response"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "schemaOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/schema"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "securitySchemeOrReference": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/securityScheme"
-        },
-        {
-          "$ref": "#/definitions/reference"
-        }
-      ]
-    },
-    "callbacksOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/callbackOrReference"
-      }
-    },
-    "examplesOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/exampleOrReference"
-      }
-    },
-    "headersMap": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/header"
-      }
-    },
-    "headersOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/headerOrReference"
-      }
-    },
-    "linksOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/linkOrReference"
-      }
-    },
-    "parametersOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/parameterOrReference"
-      }
-    },
-    "requestBodiesOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/requestBodyOrReference"
-      }
-    },
-    "responsesOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/responseOrReference"
-      }
-    },
-    "schemasOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/schemaOrReference"
-      }
-    },
-    "securitySchemesOrReferences": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/securitySchemeOrReference"
-      }
-    },
-    "strings": {
-      "type": "object",
-	  "additionalProperties": {
-	  	"type": "string"
-	  }
-    },
-    "object": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "any": {
-      "additionalProperties": true
-    },
-    "expression": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "specificationExtension": {
-      "description": "Any property starting with x- is valid.",
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "object"
-        },
-        {
-          "type": "array"
-        }
-      ]
-    },
-    "defaultType": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "array"
-        },
-        {
-          "type": "object"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ]
     }
-  }
 }

--- a/schemas/json_v5.json
+++ b/schemas/json_v5.json
@@ -6,21 +6,40 @@
         "schemaArray": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "#" }
+            "items": {
+                "$ref": "#"
+            }
         },
         "positiveInteger": {
             "type": "integer",
             "minimum": 0
         },
         "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+            "allOf": [
+                {
+                    "$ref": "#/definitions/positiveInteger"
+                },
+                {
+                    "default": 0
+                }
+            ]
         },
         "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
         },
         "stringArray": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+                "type": "string"
+            },
             "minItems": 1,
             "uniqueItems": true
         }
@@ -61,63 +80,99 @@
             "type": "boolean",
             "default": false
         },
-        "maxLength": { "$ref": "#/definitions/positiveInteger" },
-        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "maxLength": {
+            "$ref": "#/definitions/positiveInteger"
+        },
+        "minLength": {
+            "$ref": "#/definitions/positiveIntegerDefault0"
+        },
         "pattern": {
             "type": "string",
             "format": "regex"
         },
         "additionalItems": {
             "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#"
+                }
             ],
             "default": {}
         },
         "items": {
             "anyOf": [
-                { "$ref": "#" },
-                { "$ref": "#/definitions/schemaArray" }
+                {
+                    "$ref": "#"
+                },
+                {
+                    "$ref": "#/definitions/schemaArray"
+                }
             ],
             "default": {}
         },
-        "maxItems": { "$ref": "#/definitions/positiveInteger" },
-        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "maxItems": {
+            "$ref": "#/definitions/positiveInteger"
+        },
+        "minItems": {
+            "$ref": "#/definitions/positiveIntegerDefault0"
+        },
         "uniqueItems": {
             "type": "boolean",
             "default": false
         },
-        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
-        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
-        "required": { "$ref": "#/definitions/stringArray" },
+        "maxProperties": {
+            "$ref": "#/definitions/positiveInteger"
+        },
+        "minProperties": {
+            "$ref": "#/definitions/positiveIntegerDefault0"
+        },
+        "required": {
+            "$ref": "#/definitions/stringArray"
+        },
         "additionalProperties": {
             "anyOf": [
-                { "type": "boolean" },
-                { "$ref": "#" }
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#"
+                }
             ],
             "default": {}
         },
         "definitions": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": {
+                "$ref": "#"
+            },
             "default": {}
         },
         "properties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": {
+                "$ref": "#"
+            },
             "default": {}
         },
         "patternProperties": {
             "type": "object",
-            "additionalProperties": { "$ref": "#" },
+            "additionalProperties": {
+                "$ref": "#"
+            },
             "default": {}
         },
         "dependencies": {
             "type": "object",
             "additionalProperties": {
                 "anyOf": [
-                    { "$ref": "#" },
-                    { "$ref": "#/definitions/stringArray" }
+                    {
+                        "$ref": "#"
+                    },
+                    {
+                        "$ref": "#/definitions/stringArray"
+                    }
                 ]
             }
         },
@@ -128,23 +183,39 @@
         },
         "type": {
             "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "$ref": "#/definitions/simpleTypes"
+                },
                 {
                     "type": "array",
-                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "items": {
+                        "$ref": "#/definitions/simpleTypes"
+                    },
                     "minItems": 1,
                     "uniqueItems": true
                 }
             ]
         },
-        "allOf": { "$ref": "#/definitions/schemaArray" },
-        "anyOf": { "$ref": "#/definitions/schemaArray" },
-        "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
+        "allOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "anyOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "oneOf": {
+            "$ref": "#/definitions/schemaArray"
+        },
+        "not": {
+            "$ref": "#"
+        }
     },
     "dependencies": {
-        "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
+        "exclusiveMaximum": [
+            "maximum"
+        ],
+        "exclusiveMinimum": [
+            "minimum"
+        ]
     },
     "default": {}
 }

--- a/schemas/openapi-3.0.json
+++ b/schemas/openapi-3.0.json
@@ -1,2297 +1,2297 @@
 {
-  "type": "object",
-  "required": [
-    "openapi",
-    "info",
-    "paths"
-  ],
-  "properties": {
-    "openapi": {
-      "type": "string",
-      "pattern": "^3\\.0\\.\\d(-.+)?$"
-    },
-    "info": {
-      "$ref": "#/definitions/Info"
-    },
-    "externalDocs": {
-      "$ref": "#/definitions/ExternalDocumentation"
-    },
-    "servers": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Server"
-      }
-    },
-    "security": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/SecurityRequirement"
-      }
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    },
-    "paths": {
-      "$ref": "#/definitions/Paths"
-    },
-    "components": {
-      "$ref": "#/definitions/Components"
-    }
-  },
-  "patternProperties": {
-    "^x-": {}
-  },
-  "additionalProperties": false,
-  "definitions": {
-    "Reference": {
-      "type": "object",
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-          "type": "string",
-          "format": "uriref"
-        }
-      }
-    },
-    "Info": {
-      "type": "object",
-      "required": [
-        "title",
-        "version"
-      ],
-      "properties": {
-        "title": {
-          "type": "string"
+    "type": "object",
+    "required": [
+        "openapi",
+        "info",
+        "paths"
+    ],
+    "properties": {
+        "openapi": {
+            "type": "string",
+            "pattern": "^3\\.0\\.\\d(-.+)?$"
         },
-        "description": {
-          "type": "string"
+        "info": {
+            "$ref": "#/definitions/Info"
         },
-        "termsOfService": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "contact": {
-          "$ref": "#/definitions/Contact"
-        },
-        "license": {
-          "$ref": "#/definitions/License"
-        },
-        "version": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Contact": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "email": {
-          "type": "string",
-          "format": "email"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "License": {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uriref"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Server": {
-      "type": "object",
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "variables": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/ServerVariable"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ServerVariable": {
-      "type": "object",
-      "required": [
-        "default"
-      ],
-      "properties": {
-        "enum": {
-          "type": "array",
-		  "items": {
-		    "type": "string"
-		  }
-        },
-        "default": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Components": {
-      "type": "object",
-      "properties": {
-        "schemas": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Schema"
-                }
-              ]
-            }
-          }
-        },
-        "responses": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Response"
-                }
-              ]
-            }
-          }
-        },
-        "parameters": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Parameter"
-                }
-              ]
-            }
-          }
-        },
-        "examples": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Example"
-                }
-              ]
-            }
-          }
-        },
-        "requestBodies": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/RequestBody"
-                }
-              ]
-            }
-          }
-        },
-        "headers": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Header"
-                }
-              ]
-            }
-          }
-        },
-        "securitySchemes": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/SecurityScheme"
-                }
-              ]
-            }
-          }
-        },
-        "links": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Link"
-                }
-              ]
-            }
-          }
-        },
-        "callbacks": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z0-9\\.\\-_]+$": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/Reference"
-                },
-                {
-                  "$ref": "#/definitions/Callback"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Schema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "multipleOf": {
-          "type": "number",
-          "minimum": 0,
-          "exclusiveMinimum": true
-        },
-        "maximum": {
-          "type": "number"
-        },
-        "exclusiveMaximum": {
-          "type": "boolean",
-          "default": false
-        },
-        "minimum": {
-          "type": "number"
-        },
-        "exclusiveMinimum": {
-          "type": "boolean",
-          "default": false
-        },
-        "maxLength": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "minLength": {
-          "type": "integer",
-          "minimum": 0,
-          "default": 0
-        },
-        "pattern": {
-          "type": "string",
-          "format": "regex"
-        },
-        "maxItems": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "minItems": {
-          "type": "integer",
-          "minimum": 0,
-          "default": 0
-        },
-        "uniqueItems": {
-          "type": "boolean",
-          "default": false
-        },
-        "maxProperties": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "minProperties": {
-          "type": "integer",
-          "minimum": 0,
-          "default": 0
-        },
-        "required": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "enum": {
-          "type": "array",
-          "items": {},
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "array",
-            "boolean",
-            "integer",
-            "number",
-            "object",
-            "string"
-          ]
-        },
-        "not": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "allOf": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Schema"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "oneOf": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Schema"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "anyOf": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Schema"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "items": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "properties": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Schema"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            },
-            {
-              "type": "boolean"
-            }
-          ],
-          "default": true
-        },
-        "description": {
-          "type": "string"
-        },
-        "format": {
-          "type": "string"
-        },
-        "default": {},
-        "nullable": {
-          "type": "boolean",
-          "default": false
-        },
-        "discriminator": {
-          "$ref": "#/definitions/Discriminator"
-        },
-        "readOnly": {
-          "type": "boolean",
-          "default": false
-        },
-        "writeOnly": {
-          "type": "boolean",
-          "default": false
-        },
-        "example": {},
         "externalDocs": {
-          "$ref": "#/definitions/ExternalDocumentation"
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "xml": {
-          "$ref": "#/definitions/XML"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Discriminator": {
-      "type": "object",
-      "required": [
-        "propertyName"
-      ],
-      "properties": {
-        "propertyName": {
-          "type": "string"
-        },
-        "mapping": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "XML": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "namespace": {
-          "type": "string",
-          "format": "url"
-        },
-        "prefix": {
-          "type": "string"
-        },
-        "attribute": {
-          "type": "boolean",
-          "default": false
-        },
-        "wrapped": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Response": {
-      "type": "object",
-      "required": [
-        "description"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "headers": {
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Header"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          }
-        },
-        "links": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Link"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "MediaType": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/MediaTypeWithExample"
-        },
-        {
-          "$ref": "#/definitions/MediaTypeWithExamples"
-        }
-      ]
-    },
-    "MediaTypeWithExample": {
-      "type": "object",
-      "properties": {
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {},
-        "encoding": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Encoding"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "MediaTypeWithExamples": {
-      "type": "object",
-      "required": [
-        "examples"
-      ],
-      "properties": {
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "encoding": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Encoding"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Example": {
-      "type": "object",
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "value": {},
-        "externalValue": {
-          "type": "string",
-          "format": "uriref"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Header": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/HeaderWithSchema"
-        },
-        {
-          "$ref": "#/definitions/HeaderWithContent"
-        }
-      ]
-    },
-    "HeaderWithSchema": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/HeaderWithSchemaWithExample"
-        },
-        {
-          "$ref": "#/definitions/HeaderWithSchemaWithExamples"
-        }
-      ]
-    },
-    "HeaderWithSchemaWithExample": {
-      "type": "object",
-      "required": [
-        "schema"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "HeaderWithSchemaWithExamples": {
-      "type": "object",
-      "required": [
-        "schema",
-        "examples"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "HeaderWithContent": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          },
-          "minProperties": 1,
-          "maxProperties": 1
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Paths": {
-      "type": "object",
-      "patternProperties": {
-        "^\\/": {
-          "$ref": "#/definitions/PathItem"
-        },
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "PathItem": {
-      "type": "object",
-      "properties": {
-        "$ref": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "get": {
-          "$ref": "#/definitions/Operation"
-        },
-        "put": {
-          "$ref": "#/definitions/Operation"
-        },
-        "post": {
-          "$ref": "#/definitions/Operation"
-        },
-        "delete": {
-          "$ref": "#/definitions/Operation"
-        },
-        "options": {
-          "$ref": "#/definitions/Operation"
-        },
-        "head": {
-          "$ref": "#/definitions/Operation"
-        },
-        "patch": {
-          "$ref": "#/definitions/Operation"
-        },
-        "trace": {
-          "$ref": "#/definitions/Operation"
+            "$ref": "#/definitions/ExternalDocumentation"
         },
         "servers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Server"
-          }
-        },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Parameter"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Operation": {
-      "type": "object",
-      "required": [
-        "responses"
-      ],
-      "properties": {
-        "tags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/ExternalDocumentation"
-        },
-        "operationId": {
-          "type": "string"
-        },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Parameter"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "requestBody": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/RequestBody"
-            },
-            {
-              "$ref": "#/definitions/Reference"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Server"
             }
-          ]
-        },
-        "responses": {
-          "$ref": "#/definitions/Responses"
-        },
-        "callbacks": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Callback"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
         },
         "security": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SecurityRequirement"
-          }
-        },
-        "servers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Server"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Responses": {
-      "type": "object",
-      "properties": {
-        "default": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Response"
-            },
-            {
-              "$ref": "#/definitions/Reference"
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/SecurityRequirement"
             }
-          ]
-        }
-      },
-      "patternProperties": {
-        "[1-5](?:\\d{2}|XX)": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Response"
-            },
-            {
-              "$ref": "#/definitions/Reference"
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Tag"
             }
-          ]
         },
+        "paths": {
+            "$ref": "#/definitions/Paths"
+        },
+        "components": {
+            "$ref": "#/definitions/Components"
+        }
+    },
+    "patternProperties": {
         "^x-": {}
-      },
-      "minProperties": 1,
-      "additionalProperties": false,
-      "not": {
-        "type": "object",
-        "patternProperties": {
-          "^x-": {}
-        },
-        "additionalProperties": false
-      }
     },
-    "SecurityRequirement": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    },
-    "Tag": {
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "externalDocs": {
-          "$ref": "#/definitions/ExternalDocumentation"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ExternalDocumentation": {
-      "type": "object",
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uriref"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Parameter": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchema"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithContent"
-        }
-      ]
-    },
-    "ParameterWithSchema": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExample"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamples"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExample": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInPath"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInQuery"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInHeader"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExampleInCookie"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExampleInPath": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema",
-        "required"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "path"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [
-            true
-          ]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "matrix",
-            "label",
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
-            },
-            {
-              "$ref": "#/definitions/Reference"
+    "additionalProperties": false,
+    "definitions": {
+        "Reference": {
+            "type": "object",
+            "required": [
+                "$ref"
+            ],
+            "properties": {
+                "$ref": {
+                    "type": "string",
+                    "format": "uriref"
+                }
             }
-          ]
         },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInQuery": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "query"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+        "Info": {
+            "type": "object",
+            "required": [
+                "title",
+                "version"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "termsOfService": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "contact": {
+                    "$ref": "#/definitions/Contact"
+                },
+                "license": {
+                    "$ref": "#/definitions/License"
+                },
+                "version": {
+                    "type": "string"
+                }
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInHeader": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "header"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+            "patternProperties": {
+                "^x-": {}
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+            "additionalProperties": false
         },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExampleInCookie": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "cookie"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "form"
-          ],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+        "Contact": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "email": {
+                    "type": "string",
+                    "format": "email"
+                }
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "example": {}
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamples": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInPath"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInQuery"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInHeader"
-        },
-        {
-          "$ref": "#/definitions/ParameterWithSchemaWithExamplesInCookie"
-        }
-      ]
-    },
-    "ParameterWithSchemaWithExamplesInPath": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema",
-        "required",
-        "examples"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "path"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [
-            true
-          ]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "matrix",
-            "label",
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+            "patternProperties": {
+                "^x-": {}
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+            "additionalProperties": false
         },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
+        "License": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uriref"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Server": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ServerVariable"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ServerVariable": {
+            "type": "object",
+            "required": [
+                "default"
+            ],
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Components": {
+            "type": "object",
+            "properties": {
+                "schemas": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Schema"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "responses": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Response"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Parameter"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "examples": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Example"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "requestBodies": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/RequestBody"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "headers": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Header"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/SecurityScheme"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Link"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "callbacks": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Callback"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {},
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": {},
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": {},
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Discriminator": {
+            "type": "object",
+            "required": [
+                "propertyName"
+            ],
+            "properties": {
+                "propertyName": {
+                    "type": "string"
+                },
+                "mapping": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "XML": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string",
+                    "format": "url"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "attribute": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "wrapped": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Response": {
+            "type": "object",
+            "required": [
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "headers": {
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Header"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Link"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "MediaType": {
             "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
+                {
+                    "$ref": "#/definitions/MediaTypeWithExample"
+                },
+                {
+                    "$ref": "#/definitions/MediaTypeWithExamples"
+                }
             ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInQuery": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema",
-        "examples"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
         },
-        "in": {
-          "type": "string",
-          "enum": [
-            "query"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+        "MediaTypeWithExample": {
+            "type": "object",
+            "properties": {
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {},
+                "encoding": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Encoding"
+                    }
+                }
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
-        },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInHeader": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema",
-        "examples"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "header"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "simple"
-          ],
-          "default": "simple"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+            "patternProperties": {
+                "^x-": {}
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+            "additionalProperties": false
         },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
-            ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithSchemaWithExamplesInCookie": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "schema",
-        "examples"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "cookie"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "form"
-          ],
-          "default": "form"
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        },
-        "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Schema"
+        "MediaTypeWithExamples": {
+            "type": "object",
+            "required": [
+                "examples"
+            ],
+            "properties": {
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "encoding": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Encoding"
+                    }
+                }
             },
-            {
-              "$ref": "#/definitions/Reference"
-            }
-          ]
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
         },
-        "examples": {
-          "type": "object",
-          "additionalProperties": {
+        "Example": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "value": {},
+                "externalValue": {
+                    "type": "string",
+                    "format": "uriref"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Header": {
             "oneOf": [
-              {
-                "$ref": "#/definitions/Example"
-              },
-              {
-                "$ref": "#/definitions/Reference"
-              }
+                {
+                    "$ref": "#/definitions/HeaderWithSchema"
+                },
+                {
+                    "$ref": "#/definitions/HeaderWithContent"
+                }
             ]
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithContent": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ParameterWithContentInPath"
         },
-        {
-          "$ref": "#/definitions/ParameterWithContentNotInPath"
-        }
-      ]
-    },
-    "ParameterWithContentInPath": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "content"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "path"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "enum": [
-            true
-          ]
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          },
-          "minProperties": 1,
-          "maxProperties": 1
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ParameterWithContentNotInPath": {
-      "type": "object",
-      "required": [
-        "name",
-        "in",
-        "content"
-      ],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "query",
-            "header",
-            "cookie"
-          ]
-        },
-        "description": {
-          "type": "string"
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        },
-        "deprecated": {
-          "type": "boolean",
-          "default": false
-        },
-        "allowEmptyValue": {
-          "type": "boolean",
-          "default": false
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          },
-          "minProperties": 1,
-          "maxProperties": 1
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "RequestBody": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "content": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/MediaType"
-          }
-        },
-        "required": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "SecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/APIKeySecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/HTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/OAuth2SecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/OpenIdConnectSecurityScheme"
-        }
-      ]
-    },
-    "APIKeySecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "name",
-        "in"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "apiKey"
-          ]
-        },
-        "name": {
-          "type": "string"
-        },
-        "in": {
-          "type": "string",
-          "enum": [
-            "header",
-            "query",
-            "cookie"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "HTTPSecurityScheme": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
-        },
-        {
-          "$ref": "#/definitions/BearerHTTPSecurityScheme"
-        }
-      ]
-    },
-    "NonBearerHTTPSecurityScheme": {
-      "not": {
-        "type": "object",
-        "properties": {
-          "scheme": {
-            "type": "string",
-            "enum": [
-              "bearer"
+        "HeaderWithSchema": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/HeaderWithSchemaWithExample"
+                },
+                {
+                    "$ref": "#/definitions/HeaderWithSchemaWithExamples"
+                }
             ]
-          }
+        },
+        "HeaderWithSchemaWithExample": {
+            "type": "object",
+            "required": [
+                "schema"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HeaderWithSchemaWithExamples": {
+            "type": "object",
+            "required": [
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HeaderWithContent": {
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Paths": {
+            "type": "object",
+            "patternProperties": {
+                "^\\/": {
+                    "$ref": "#/definitions/PathItem"
+                },
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "PathItem": {
+            "type": "object",
+            "properties": {
+                "$ref": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "get": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "put": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "post": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "delete": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "options": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "head": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "patch": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "trace": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Server"
+                    }
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Parameter"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Operation": {
+            "type": "object",
+            "required": [
+                "responses"
+            ],
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Parameter"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "requestBody": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/RequestBody"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "responses": {
+                    "$ref": "#/definitions/Responses"
+                },
+                "callbacks": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Callback"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SecurityRequirement"
+                    }
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Server"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Responses": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Response"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                }
+            },
+            "patternProperties": {
+                "[1-5](?:\\d{2}|XX)": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Response"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "^x-": {}
+            },
+            "minProperties": 1,
+            "additionalProperties": false,
+            "not": {
+                "type": "object",
+                "patternProperties": {
+                    "^x-": {}
+                },
+                "additionalProperties": false
+            }
+        },
+        "SecurityRequirement": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ExternalDocumentation": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uriref"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Parameter": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchema"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithContent"
+                }
+            ]
+        },
+        "ParameterWithSchema": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExample"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamples"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExample": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInQuery"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInHeader"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInCookie"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExampleInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "required"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "matrix",
+                        "label",
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInQuery": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInHeader": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInCookie": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamples": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInQuery"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInHeader"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInCookie"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExamplesInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "required",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "matrix",
+                        "label",
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInQuery": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInHeader": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInCookie": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithContent": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithContentInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithContentNotInPath"
+                }
+            ]
+        },
+        "ParameterWithContentInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "content"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithContentNotInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "content"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query",
+                        "header",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "RequestBody": {
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    }
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "SecurityScheme": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/APIKeySecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/HTTPSecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/OAuth2SecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+                }
+            ]
+        },
+        "APIKeySecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HTTPSecurityScheme": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
+                }
+            ]
+        },
+        "NonBearerHTTPSecurityScheme": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "scheme": {
+                        "type": "string",
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "BearerHTTPSecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OAuth2SecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "flows": {
+                    "$ref": "#/definitions/OAuthFlows"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OpenIdConnectSecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "url"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OAuthFlows": {
+            "type": "object",
+            "properties": {
+                "implicit": {
+                    "$ref": "#/definitions/ImplicitOAuthFlow"
+                },
+                "password": {
+                    "$ref": "#/definitions/PasswordOAuthFlow"
+                },
+                "clientCredentials": {
+                    "$ref": "#/definitions/ClientCredentialsFlow"
+                },
+                "authorizationCode": {
+                    "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ImplicitOAuthFlow": {
+            "type": "object",
+            "required": [
+                "authorizationUrl",
+                "scopes"
+            ],
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "PasswordOAuthFlow": {
+            "type": "object",
+            "required": [
+                "tokenUrl"
+            ],
+            "properties": {
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ClientCredentialsFlow": {
+            "type": "object",
+            "required": [
+                "tokenUrl"
+            ],
+            "properties": {
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "AuthorizationCodeOAuthFlow": {
+            "type": "object",
+            "required": [
+                "authorizationUrl",
+                "tokenUrl"
+            ],
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Link": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/LinkWithOperationRef"
+                },
+                {
+                    "$ref": "#/definitions/LinkWithOperationId"
+                }
+            ]
+        },
+        "LinkWithOperationRef": {
+            "type": "object",
+            "properties": {
+                "operationRef": {
+                    "type": "string",
+                    "format": "uriref"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "requestBody": {},
+                "description": {
+                    "type": "string"
+                },
+                "server": {
+                    "$ref": "#/definitions/Server"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "LinkWithOperationId": {
+            "type": "object",
+            "properties": {
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "requestBody": {},
+                "description": {
+                    "type": "string"
+                },
+                "server": {
+                    "$ref": "#/definitions/Server"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Callback": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/PathItem"
+            },
+            "patternProperties": {
+                "^x-": {}
+            }
+        },
+        "Encoding": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Header"
+                    }
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ]
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
         }
-      },
-      "type": "object",
-      "required": [
-        "scheme",
-        "type"
-      ],
-      "properties": {
-        "scheme": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "http"
-          ]
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "BearerHTTPSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "scheme"
-      ],
-      "properties": {
-        "scheme": {
-          "type": "string",
-          "enum": [
-            "bearer"
-          ]
-        },
-        "bearerFormat": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "http"
-          ]
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "OAuth2SecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "flows"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "oauth2"
-          ]
-        },
-        "flows": {
-          "$ref": "#/definitions/OAuthFlows"
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "OpenIdConnectSecurityScheme": {
-      "type": "object",
-      "required": [
-        "type",
-        "openIdConnectUrl"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "openIdConnect"
-          ]
-        },
-        "openIdConnectUrl": {
-          "type": "string",
-          "format": "url"
-        },
-        "description": {
-          "type": "string"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "OAuthFlows": {
-      "type": "object",
-      "properties": {
-        "implicit": {
-          "$ref": "#/definitions/ImplicitOAuthFlow"
-        },
-        "password": {
-          "$ref": "#/definitions/PasswordOAuthFlow"
-        },
-        "clientCredentials": {
-          "$ref": "#/definitions/ClientCredentialsFlow"
-        },
-        "authorizationCode": {
-          "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ImplicitOAuthFlow": {
-      "type": "object",
-      "required": [
-        "authorizationUrl",
-        "scopes"
-      ],
-      "properties": {
-        "authorizationUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "refreshUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "scopes": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "PasswordOAuthFlow": {
-      "type": "object",
-      "required": [
-        "tokenUrl"
-      ],
-      "properties": {
-        "tokenUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "refreshUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "scopes": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "ClientCredentialsFlow": {
-      "type": "object",
-      "required": [
-        "tokenUrl"
-      ],
-      "properties": {
-        "tokenUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "refreshUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "scopes": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "AuthorizationCodeOAuthFlow": {
-      "type": "object",
-      "required": [
-        "authorizationUrl",
-        "tokenUrl"
-      ],
-      "properties": {
-        "authorizationUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "tokenUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "refreshUrl": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "scopes": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Link": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/LinkWithOperationRef"
-        },
-        {
-          "$ref": "#/definitions/LinkWithOperationId"
-        }
-      ]
-    },
-    "LinkWithOperationRef": {
-      "type": "object",
-      "properties": {
-        "operationRef": {
-          "type": "string",
-          "format": "uriref"
-        },
-        "parameters": {
-          "type": "object",
-          "additionalProperties": {}
-        },
-        "requestBody": {},
-        "description": {
-          "type": "string"
-        },
-        "server": {
-          "$ref": "#/definitions/Server"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "LinkWithOperationId": {
-      "type": "object",
-      "properties": {
-        "operationId": {
-          "type": "string"
-        },
-        "parameters": {
-          "type": "object",
-          "additionalProperties": {}
-        },
-        "requestBody": {},
-        "description": {
-          "type": "string"
-        },
-        "server": {
-          "$ref": "#/definitions/Server"
-        }
-      },
-      "patternProperties": {
-        "^x-": {}
-      },
-      "additionalProperties": false
-    },
-    "Callback": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/PathItem"
-      },
-      "patternProperties": {
-        "^x-": {}
-      }
-    },
-    "Encoding": {
-      "type": "object",
-      "properties": {
-        "contentType": {
-          "type": "string"
-        },
-        "headers": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Header"
-          }
-        },
-        "style": {
-          "type": "string",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ]
-        },
-        "explode": {
-          "type": "boolean"
-        },
-        "allowReserved": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "additionalProperties": false
     }
-  }
 }

--- a/statusCodes.js
+++ b/statusCodes.js
@@ -254,5 +254,5 @@ var statusCodes = [
 ];
 
 module.exports = {
-	statusCodes : statusCodes
+    statusCodes : statusCodes
 };

--- a/statusCodes.js
+++ b/statusCodes.js
@@ -254,5 +254,5 @@ var statusCodes = [
 ];
 
 module.exports = {
-    statusCodes : statusCodes
+    statusCodes: statusCodes
 };

--- a/swagger2openapi.js
+++ b/swagger2openapi.js
@@ -12,33 +12,33 @@ var converter = require('./index.js');
 
 // @ts-ignore
 var argv = require('yargs')
-	.boolean('components')
-	.alias('c','components')
-	.describe('components','output information to unresolve a definition')
-	.boolean('debug')
-	.alias('d','debug')
-	.describe('debug','enable debug mode, adds specification-extensions')
-	.string('encoding')
-	.alias('e','encoding')
-	.default('encoding','utf8')
-	.describe('encoding','encoding for input/output files')
+    .boolean('components')
+    .alias('c','components')
+    .describe('components','output information to unresolve a definition')
+    .boolean('debug')
+    .alias('d','debug')
+    .describe('debug','enable debug mode, adds specification-extensions')
+    .string('encoding')
+    .alias('e','encoding')
+    .default('encoding','utf8')
+    .describe('encoding','encoding for input/output files')
     .help('help')
     .alias('h','help')
     .string('outfile')
     .alias('o','outfile')
     .describe('outfile', 'the output file to write to')
-	.boolean('patch')
-	.alias('p','patch')
-	.describe('patch','fix up small errors in the source definition')
-	.boolean('resolve')
-	.alias('r','resolve')
-	.describe('resolve','resolve external references')
-	.string('url')
-	.describe('url','url of original spec, creates x-origin entry')
-	.alias('u','url')
-	.count('verbose')
-	.alias('v','verbose')
-	.describe('verbose','increase verbosity')
+    .boolean('patch')
+    .alias('p','patch')
+    .describe('patch','fix up small errors in the source definition')
+    .boolean('resolve')
+    .alias('r','resolve')
+    .describe('resolve','resolve external references')
+    .string('url')
+    .describe('url','url of original spec, creates x-origin entry')
+    .alias('u','url')
+    .count('verbose')
+    .alias('v','verbose')
+    .describe('verbose','increase verbosity')
     .boolean('yaml')
     .alias('y','yaml')
     .describe('yaml', 'read and write YAML, default JSON')
@@ -47,45 +47,45 @@ var argv = require('yargs')
     .argv;
 
 function processResult(err, options) {
-	if (err) {
-		delete err.options;
-		console.log(util.inspect(err));
-		return process.exitCode = 1;
-	}
-	if (options.yaml && options.outfile && options.outfile.indexOf('.json') > 0) {
+    if (err) {
+        delete err.options;
+        console.log(util.inspect(err));
+        return process.exitCode = 1;
+    }
+    if (options.yaml && options.outfile && options.outfile.indexOf('.json') > 0) {
         options.yaml = false;
-	}
-	if (!options.yaml && options.outfile && options.outfile.indexOf('.yaml') > 0) {
+    }
+    if (!options.yaml && options.outfile && options.outfile.indexOf('.yaml') > 0) {
         options.yaml = true;
-	}
+    }
 
-	var s;
-	if (options.yaml) {
-		s = options.debug ? yaml.dump(options.openapi) : yaml.safeDump(options.openapi);
-	}
-	else {
-		s = JSON.stringify(options.openapi, null, 2);
-	}
+    var s;
+    if (options.yaml) {
+        s = options.debug ? yaml.dump(options.openapi) : yaml.safeDump(options.openapi);
+    }
+    else {
+        s = JSON.stringify(options.openapi, null, 2);
+    }
 
-	if (argv.outfile) {
-		fs.writeFileSync(options.outfile, s, options.encoding||'utf8');
-	}
-	else {
-		console.log(s);
-	}
+    if (argv.outfile) {
+        fs.writeFileSync(options.outfile, s, options.encoding||'utf8');
+    }
+    else {
+        console.log(s);
+    }
 
-	if (argv.components) {
-		console.log(JSON.stringify(options.externals,null,2));
-	}
+    if (argv.components) {
+        console.log(JSON.stringify(options.externals,null,2));
+    }
 }
 
 argv.source = argv._[0];
 var u = url.parse(argv.source);
 if (u.protocol) {
-	converter.convertUrl(argv.source,argv,processResult);
+    converter.convertUrl(argv.source,argv,processResult);
 }
 else {
-	argv.origin = argv.url;
-	converter.convertFile(argv.source,argv,processResult);
+    argv.origin = argv.url;
+    converter.convertFile(argv.source,argv,processResult);
 }
 

--- a/swagger2openapi.js
+++ b/swagger2openapi.js
@@ -13,34 +13,34 @@ var converter = require('./index.js');
 // @ts-ignore
 var argv = require('yargs')
     .boolean('components')
-    .alias('c','components')
-    .describe('components','output information to unresolve a definition')
+    .alias('c', 'components')
+    .describe('components', 'output information to unresolve a definition')
     .boolean('debug')
-    .alias('d','debug')
-    .describe('debug','enable debug mode, adds specification-extensions')
+    .alias('d', 'debug')
+    .describe('debug', 'enable debug mode, adds specification-extensions')
     .string('encoding')
-    .alias('e','encoding')
-    .default('encoding','utf8')
-    .describe('encoding','encoding for input/output files')
+    .alias('e', 'encoding')
+    .default('encoding', 'utf8')
+    .describe('encoding', 'encoding for input/output files')
     .help('help')
-    .alias('h','help')
+    .alias('h', 'help')
     .string('outfile')
-    .alias('o','outfile')
+    .alias('o', 'outfile')
     .describe('outfile', 'the output file to write to')
     .boolean('patch')
-    .alias('p','patch')
-    .describe('patch','fix up small errors in the source definition')
+    .alias('p', 'patch')
+    .describe('patch', 'fix up small errors in the source definition')
     .boolean('resolve')
-    .alias('r','resolve')
-    .describe('resolve','resolve external references')
+    .alias('r', 'resolve')
+    .describe('resolve', 'resolve external references')
     .string('url')
-    .describe('url','url of original spec, creates x-origin entry')
-    .alias('u','url')
+    .describe('url', 'url of original spec, creates x-origin entry')
+    .alias('u', 'url')
     .count('verbose')
-    .alias('v','verbose')
-    .describe('verbose','increase verbosity')
+    .alias('v', 'verbose')
+    .describe('verbose', 'increase verbosity')
     .boolean('yaml')
-    .alias('y','yaml')
+    .alias('y', 'yaml')
     .describe('yaml', 'read and write YAML, default JSON')
     .require(1)
     .strict()
@@ -68,24 +68,24 @@ function processResult(err, options) {
     }
 
     if (argv.outfile) {
-        fs.writeFileSync(options.outfile, s, options.encoding||'utf8');
+        fs.writeFileSync(options.outfile, s, options.encoding || 'utf8');
     }
     else {
         console.log(s);
     }
 
     if (argv.components) {
-        console.log(JSON.stringify(options.externals,null,2));
+        console.log(JSON.stringify(options.externals, null, 2));
     }
 }
 
 argv.source = argv._[0];
 var u = url.parse(argv.source);
 if (u.protocol) {
-    converter.convertUrl(argv.source,argv,processResult);
+    converter.convertUrl(argv.source, argv, processResult);
 }
 else {
     argv.origin = argv.url;
-    converter.convertFile(argv.source,argv,processResult);
+    converter.convertFile(argv.source, argv, processResult);
 }
 

--- a/testRunner.js
+++ b/testRunner.js
@@ -14,46 +14,46 @@ var validator = require('./validate.js');
 var argv = require('yargs')
     .usage('testRunner [options] [{path-to-specs}...]')
     .string('encoding')
-    .alias('e','encoding')
-    .default('encoding','utf8')
-    .describe('encoding','encoding for input/output files')
+    .alias('e', 'encoding')
+    .default('encoding', 'utf8')
+    .describe('encoding', 'encoding for input/output files')
     .string('fail')
-    .describe('fail','path to specs expected to fail')
-    .alias('f','fail')
+    .describe('fail', 'path to specs expected to fail')
+    .alias('f', 'fail')
     .string('jsonschema')
-    .alias('j','jsonschema')
-    .describe('jsonschema','path to alternative JSON schema')
+    .alias('j', 'jsonschema')
+    .describe('jsonschema', 'path to alternative JSON schema')
     .boolean('laxurls')
-    .alias('l','laxurls')
-    .describe('laxurls','lax checking of empty urls')
+    .alias('l', 'laxurls')
+    .describe('laxurls', 'lax checking of empty urls')
     .boolean('nopatch')
-    .alias('n','nopatch')
-    .describe('nopatch','do not patch minor errors in the source definition')
+    .alias('n', 'nopatch')
+    .describe('nopatch', 'do not patch minor errors in the source definition')
     .boolean('output')
-    .alias('o','output')
-    .describe('output','output conversion as openapi.yaml')
+    .alias('o', 'output')
+    .describe('output', 'output conversion as openapi.yaml')
     .boolean('quiet')
-    .alias('q','quiet')
-    .describe('quiet','do not show test passes on console, for CI')
+    .alias('q', 'quiet')
+    .describe('quiet', 'do not show test passes on console, for CI')
     .boolean('resolve')
-    .alias('r','resolve')
-    .describe('resolve','resolve external references')
+    .alias('r', 'resolve')
+    .describe('resolve', 'resolve external references')
     .boolean('stop')
-    .alias('s','stop')
-    .describe('stop','stop on first error')
+    .alias('s', 'stop')
+    .describe('stop', 'stop on first error')
     .count('verbose')
-    .alias('v','verbose')
-    .describe('verbose','increase verbosity')
+    .alias('v', 'verbose')
+    .describe('verbose', 'increase verbosity')
     .boolean('whatwg')
-    .alias('w','whatwg')
-    .describe('whatwg','enable WHATWG URL parsing')
+    .alias('w', 'whatwg')
+    .describe('whatwg', 'enable WHATWG URL parsing')
     .boolean('yaml')
-    .alias('y','yaml')
-    .describe('yaml','skip YAML-safe test')
+    .alias('y', 'yaml')
+    .describe('yaml', 'skip YAML-safe test')
     .help('h')
     .alias('h', 'help')
     .strict()
-    .version(function() {
+    .version(function () {
         return require('../package.json').version;
     })
     .argv;
@@ -76,9 +76,9 @@ options.patch = !argv.nopatch;
 function handleResult(err, options) {
     var result = false;
     if (err) {
-        options = err.options||{file:'unknown',src:{info:{version:'',title:''}}};
-        console.log(normal+options.file);
-        console.log(red+'Converter: '+err.message);
+        options = err.options || { file: 'unknown', src: { info: { version: '', title: '' } } };
+        console.log(normal + options.file);
+        console.log(red + 'Converter: ' + err.message);
     }
     else {
         result = options.openapi;
@@ -88,36 +88,36 @@ function handleResult(err, options) {
     if (typeof result !== 'boolean') try {
         var src = options.original;
         if (!options.yaml) {
-            resultStr = yaml.safeDump(result,{lineWidth:-1}); // should be representable safely in yaml
+            resultStr = yaml.safeDump(result, { lineWidth: -1 }); // should be representable safely in yaml
             resultStr.should.not.be.exactly('{}');
         }
 
-        result = validator.validateSync(result,options);
+        result = validator.validateSync(result, options);
 
         for (var warning of options.warnings) {
-            warnings.push(options.file+' '+warning);
+            warnings.push(options.file + ' ' + warning);
         }
 
         if (!argv.quiet) {
-            console.log(normal+options.file);
+            console.log(normal + options.file);
             var colour = ((options.expectFailure ? !result : result) ? green : red);
-            console.log(colour+'  %s %s',src.info.title,src.info.version);
-            console.log('  %s',src.swagger ? (src.host ? src.host : 'relative') : (src.servers && src.servers.length ? src.servers[0].url : 'relative'));
+            console.log(colour + '  %s %s', src.info.title, src.info.version);
+            console.log('  %s', src.swagger ? (src.host ? src.host : 'relative') : (src.servers && src.servers.length ? src.servers[0].url : 'relative'));
         }
     }
-    catch (ex) {
-        console.log(normal+options.file);
-        console.log(red+options.context.pop()+'\n'+ex.message);
-        result = !!options.expectFailure;
-        if (ex.stack && ex.name !== 'AssertionError') {
-            console.log(ex.stack);
+        catch (ex) {
+            console.log(normal + options.file);
+            console.log(red + options.context.pop() + '\n' + ex.message);
+            result = !!options.expectFailure;
+            if (ex.stack && ex.name !== 'AssertionError') {
+                console.log(ex.stack);
+            }
         }
-    }
     if (result) {
         pass++;
-        if ((options.file.indexOf('swagger.yaml')>=0) && argv.output) {
-            let outFile = options.file.replace('swagger.yaml','openapi.yaml');
-            fs.writeFile(outFile,resultStr,argv.encoding);
+        if ((options.file.indexOf('swagger.yaml') >= 0) && argv.output) {
+            let outFile = options.file.replace('swagger.yaml', 'openapi.yaml');
+            fs.writeFile(outFile, resultStr, argv.encoding);
         }
     }
     else {
@@ -135,28 +135,28 @@ function genStackNext() {
     return true;
 }
 
-function* check(file,force,expectFailure) {
+function* check(file, force, expectFailure) {
     var result = false;
     options.context = [];
     options.expectFailure = expectFailure;
     options.file = file;
     var components = file.split(path.sep);
-    var name = components[components.length-1];
+    var name = components[components.length - 1];
 
-    if ((name.indexOf('.yaml')>=0) || (name.indexOf('.json')>=0) || force) {
+    if ((name.indexOf('.yaml') >= 0) || (name.indexOf('.json') >= 0) || force) {
 
-        var srcStr = fs.readFileSync(path.resolve(file),options.encoding);
+        var srcStr = fs.readFileSync(path.resolve(file), options.encoding);
         var src;
         try {
             src = JSON.parse(srcStr);
         }
         catch (ex) {
             try {
-                src = yaml.safeLoad(srcStr,{schema:yaml.JSON_SCHEMA,json:true});
+                src = yaml.safeLoad(srcStr, { schema: yaml.JSON_SCHEMA, json: true });
             }
             catch (ex) {
-                var warning = 'Could not parse file '+file+'\n'+ex.message;
-                console.log(red+warning);
+                var warning = 'Could not parse file ' + file + '\n' + ex.message;
+                console.log(red + warning);
                 warnings.push(warning);
             }
         }
@@ -173,8 +173,8 @@ function* check(file,force,expectFailure) {
             swagger2openapi.convertObj(src, common.clone(options), handleResult);
         }
         catch (ex) {
-            console.log(red+'Converter threw an error: '+ex.message);
-            warnings.push('Converter failed '+options.source);
+            console.log(red + 'Converter threw an error: ' + ex.message);
+            warnings.push('Converter failed ' + options.source);
             genStackNext();
             result = false;
         }
@@ -187,33 +187,33 @@ function* check(file,force,expectFailure) {
     return result;
 }
 
-function processPathSpec(pathspec,expectFailure) {
+function processPathSpec(pathspec, expectFailure) {
     if (pathspec.startsWith('@')) {
-        pathspec = pathspec.substr(1,pathspec.length-1);
-        var list = fs.readFileSync(pathspec,'utf8').split('\r').join('').split('\n');
+        pathspec = pathspec.substr(1, pathspec.length - 1);
+        var list = fs.readFileSync(pathspec, 'utf8').split('\r').join('').split('\n');
         for (var file of list) {
-            genStack.push(check(file,false,expectFailure));
+            genStack.push(check(file, false, expectFailure));
         }
         genStackNext();
     }
     else if (fs.statSync(path.resolve(pathspec)).isFile()) {
-        genStack.push(check(pathspec,true,expectFailure));
+        genStack.push(check(pathspec, true, expectFailure));
         genStackNext();
     }
     else {
-        readfiles(pathspec, {readContents: false, filenameFormat: readfiles.FULL_PATH}, function (err) {
+        readfiles(pathspec, { readContents: false, filenameFormat: readfiles.FULL_PATH }, function (err) {
             if (err) console.log(util.inspect(err));
         })
-        .then(files => {
-            files = files.sort();
-            for (var file of files) {
-                genStack.push(check(file,false,expectFailure));
-            }
-            genStackNext();
-        })
-        .catch(err => {
-            console.log(util.inspect(err));
-        });
+            .then(files => {
+                files = files.sort();
+                for (var file of files) {
+                    genStack.push(check(file, false, expectFailure));
+                }
+                genStackNext();
+            })
+            .catch(err => {
+                console.log(util.inspect(err));
+            });
     }
 }
 
@@ -223,26 +223,26 @@ if ((!argv._.length) && (!argv.fail)) {
     argv._.push('../openapi-directory/APIs/');
 }
 for (let pathspec of argv._) {
-    processPathSpec(pathspec,false);
+    processPathSpec(pathspec, false);
 }
 if (argv.fail) {
     if (!Array.isArray(argv.fail)) argv.fail = [argv.fail];
     for (let pathspec of argv.fail) {
-        processPathSpec(pathspec,true);
+        processPathSpec(pathspec, true);
     }
 }
 
-process.on('exit', function() {
+process.on('exit', function () {
     if (warnings.length) {
         warnings.sort();
-        console.log(normal+'\nWarnings:'+yellow);
+        console.log(normal + '\nWarnings:' + yellow);
         for (var w in warnings) {
             console.log(warnings[w]);
         }
     }
     if (failures.length) {
         failures.sort();
-        console.log(normal+'\nFailures:'+red);
+        console.log(normal + '\nFailures:' + red);
         for (var f in failures) {
             console.log(failures[f]);
         }

--- a/testRunner.js
+++ b/testRunner.js
@@ -12,51 +12,51 @@ var swagger2openapi = require('./index.js');
 var validator = require('./validate.js');
 
 var argv = require('yargs')
-	.usage('testRunner [options] [{path-to-specs}...]')
-	.string('encoding')
-	.alias('e','encoding')
-	.default('encoding','utf8')
-	.describe('encoding','encoding for input/output files')
-	.string('fail')
-	.describe('fail','path to specs expected to fail')
-	.alias('f','fail')
-	.string('jsonschema')
-	.alias('j','jsonschema')
-	.describe('jsonschema','path to alternative JSON schema')
-	.boolean('laxurls')
-	.alias('l','laxurls')
-	.describe('laxurls','lax checking of empty urls')
-	.boolean('nopatch')
-	.alias('n','nopatch')
-	.describe('nopatch','do not patch minor errors in the source definition')
-	.boolean('output')
-	.alias('o','output')
-	.describe('output','output conversion as openapi.yaml')
-	.boolean('quiet')
-	.alias('q','quiet')
-	.describe('quiet','do not show test passes on console, for CI')
-	.boolean('resolve')
-	.alias('r','resolve')
-	.describe('resolve','resolve external references')
-	.boolean('stop')
-	.alias('s','stop')
-	.describe('stop','stop on first error')
-	.count('verbose')
-	.alias('v','verbose')
-	.describe('verbose','increase verbosity')
-	.boolean('whatwg')
-	.alias('w','whatwg')
-	.describe('whatwg','enable WHATWG URL parsing')
-	.boolean('yaml')
-	.alias('y','yaml')
-	.describe('yaml','skip YAML-safe test')
-	.help('h')
+    .usage('testRunner [options] [{path-to-specs}...]')
+    .string('encoding')
+    .alias('e','encoding')
+    .default('encoding','utf8')
+    .describe('encoding','encoding for input/output files')
+    .string('fail')
+    .describe('fail','path to specs expected to fail')
+    .alias('f','fail')
+    .string('jsonschema')
+    .alias('j','jsonschema')
+    .describe('jsonschema','path to alternative JSON schema')
+    .boolean('laxurls')
+    .alias('l','laxurls')
+    .describe('laxurls','lax checking of empty urls')
+    .boolean('nopatch')
+    .alias('n','nopatch')
+    .describe('nopatch','do not patch minor errors in the source definition')
+    .boolean('output')
+    .alias('o','output')
+    .describe('output','output conversion as openapi.yaml')
+    .boolean('quiet')
+    .alias('q','quiet')
+    .describe('quiet','do not show test passes on console, for CI')
+    .boolean('resolve')
+    .alias('r','resolve')
+    .describe('resolve','resolve external references')
+    .boolean('stop')
+    .alias('s','stop')
+    .describe('stop','stop on first error')
+    .count('verbose')
+    .alias('v','verbose')
+    .describe('verbose','increase verbosity')
+    .boolean('whatwg')
+    .alias('w','whatwg')
+    .describe('whatwg','enable WHATWG URL parsing')
+    .boolean('yaml')
+    .alias('y','yaml')
+    .describe('yaml','skip YAML-safe test')
+    .help('h')
     .alias('h', 'help')
-	.strict()
-	.version(function() {
-		return require('../package.json').version;
-	})
-	.argv;
+    .strict()
+    .version(function() {
+        return require('../package.json').version;
+    })
+    .argv;
 
 var red = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[31m';
 var green = process.env.NODE_DISABLE_COLORS ? '' : '\x1b[32m';
@@ -74,180 +74,180 @@ var options = argv;
 options.patch = !argv.nopatch;
 
 function handleResult(err, options) {
-	var result = false;
-	if (err) {
-		options = err.options||{file:'unknown',src:{info:{version:'',title:''}}};
-		console.log(normal+options.file);
-		console.log(red+'Converter: '+err.message);
-	}
-	else {
-		result = options.openapi;
-	}
-	var resultStr = JSON.stringify(result);
+    var result = false;
+    if (err) {
+        options = err.options||{file:'unknown',src:{info:{version:'',title:''}}};
+        console.log(normal+options.file);
+        console.log(red+'Converter: '+err.message);
+    }
+    else {
+        result = options.openapi;
+    }
+    var resultStr = JSON.stringify(result);
 
-	if (typeof result !== 'boolean') try {
-		var src = options.original;
-		if (!options.yaml) {
-			resultStr = yaml.safeDump(result,{lineWidth:-1}); // should be representable safely in yaml
-			resultStr.should.not.be.exactly('{}');
-		}
+    if (typeof result !== 'boolean') try {
+        var src = options.original;
+        if (!options.yaml) {
+            resultStr = yaml.safeDump(result,{lineWidth:-1}); // should be representable safely in yaml
+            resultStr.should.not.be.exactly('{}');
+        }
 
-		result = validator.validateSync(result,options);
+        result = validator.validateSync(result,options);
 
-		for (var warning of options.warnings) {
-			warnings.push(options.file+' '+warning);
-		}
+        for (var warning of options.warnings) {
+            warnings.push(options.file+' '+warning);
+        }
 
-		if (!argv.quiet) {
-			console.log(normal+options.file);
-			var colour = ((options.expectFailure ? !result : result) ? green : red);
-			console.log(colour+'  %s %s',src.info.title,src.info.version);
-			console.log('  %s',src.swagger ? (src.host ? src.host : 'relative') : (src.servers && src.servers.length ? src.servers[0].url : 'relative'));
-		}
-	}
-	catch (ex) {
-		console.log(normal+options.file);
-		console.log(red+options.context.pop()+'\n'+ex.message);
-		result = !!options.expectFailure;
-		if (ex.stack && ex.name !== 'AssertionError') {
-			console.log(ex.stack);
-		}
-	}
-	if (result) {
-		pass++;
-		if ((options.file.indexOf('swagger.yaml')>=0) && argv.output) {
-			let outFile = options.file.replace('swagger.yaml','openapi.yaml');
-			fs.writeFile(outFile,resultStr,argv.encoding);
-		}
-	}
-	else {
-		fail++;
-		if (options.file != 'unknown') failures.push(options.file);
-		if (argv.stop) process.exit(1);
-	}
-	genStackNext();
+        if (!argv.quiet) {
+            console.log(normal+options.file);
+            var colour = ((options.expectFailure ? !result : result) ? green : red);
+            console.log(colour+'  %s %s',src.info.title,src.info.version);
+            console.log('  %s',src.swagger ? (src.host ? src.host : 'relative') : (src.servers && src.servers.length ? src.servers[0].url : 'relative'));
+        }
+    }
+    catch (ex) {
+        console.log(normal+options.file);
+        console.log(red+options.context.pop()+'\n'+ex.message);
+        result = !!options.expectFailure;
+        if (ex.stack && ex.name !== 'AssertionError') {
+            console.log(ex.stack);
+        }
+    }
+    if (result) {
+        pass++;
+        if ((options.file.indexOf('swagger.yaml')>=0) && argv.output) {
+            let outFile = options.file.replace('swagger.yaml','openapi.yaml');
+            fs.writeFile(outFile,resultStr,argv.encoding);
+        }
+    }
+    else {
+        fail++;
+        if (options.file != 'unknown') failures.push(options.file);
+        if (argv.stop) process.exit(1);
+    }
+    genStackNext();
 }
 
 function genStackNext() {
-	if (!genStack.length) return false;
-	var gen = genStack.shift();
-	gen.next();
-	return true;
+    if (!genStack.length) return false;
+    var gen = genStack.shift();
+    gen.next();
+    return true;
 }
 
 function* check(file,force,expectFailure) {
-	var result = false;
-	options.context = [];
-	options.expectFailure = expectFailure;
-	options.file = file;
-	var components = file.split(path.sep);
-	var name = components[components.length-1];
+    var result = false;
+    options.context = [];
+    options.expectFailure = expectFailure;
+    options.file = file;
+    var components = file.split(path.sep);
+    var name = components[components.length-1];
 
-	if ((name.indexOf('.yaml')>=0) || (name.indexOf('.json')>=0) || force) {
+    if ((name.indexOf('.yaml')>=0) || (name.indexOf('.json')>=0) || force) {
 
-		var srcStr = fs.readFileSync(path.resolve(file),options.encoding);
-		var src;
-		try {
-			src = JSON.parse(srcStr);
-		}
-		catch (ex) {
-			try {
-				src = yaml.safeLoad(srcStr,{schema:yaml.JSON_SCHEMA,json:true});
-			}
-			catch (ex) {
-				var warning = 'Could not parse file '+file+'\n'+ex.message;
-				console.log(red+warning);
-				warnings.push(warning);
-			}
-		}
+        var srcStr = fs.readFileSync(path.resolve(file),options.encoding);
+        var src;
+        try {
+            src = JSON.parse(srcStr);
+        }
+        catch (ex) {
+            try {
+                src = yaml.safeLoad(srcStr,{schema:yaml.JSON_SCHEMA,json:true});
+            }
+            catch (ex) {
+                var warning = 'Could not parse file '+file+'\n'+ex.message;
+                console.log(red+warning);
+                warnings.push(warning);
+            }
+        }
 
-		if (!src || ((!src.swagger && !src.openapi))) {
-			genStackNext();
-			return true;
-		}
+        if (!src || ((!src.swagger && !src.openapi))) {
+            genStackNext();
+            return true;
+        }
 
-		options.original = src;
-		options.source = file;
+        options.original = src;
+        options.source = file;
 
-		try {
-			swagger2openapi.convertObj(src, common.clone(options), handleResult);
-		}
-		catch (ex) {
-			console.log(red+'Converter threw an error: '+ex.message);
-			warnings.push('Converter failed '+options.source);
-			genStackNext();
-			result = false;
-		}
+        try {
+            swagger2openapi.convertObj(src, common.clone(options), handleResult);
+        }
+        catch (ex) {
+            console.log(red+'Converter threw an error: '+ex.message);
+            warnings.push('Converter failed '+options.source);
+            genStackNext();
+            result = false;
+        }
 
-	}
-	else {
-		genStackNext();
-		result = true;
-	}
-	return result;
+    }
+    else {
+        genStackNext();
+        result = true;
+    }
+    return result;
 }
 
 function processPathSpec(pathspec,expectFailure) {
-	if (pathspec.startsWith('@')) {
-		pathspec = pathspec.substr(1,pathspec.length-1);
-		var list = fs.readFileSync(pathspec,'utf8').split('\r').join('').split('\n');
-		for (var file of list) {
-			genStack.push(check(file,false,expectFailure));
-		}
-		genStackNext();
-	}
-	else if (fs.statSync(path.resolve(pathspec)).isFile()) {
-		genStack.push(check(pathspec,true,expectFailure));
-		genStackNext();
-	}
-	else {
-		readfiles(pathspec, {readContents: false, filenameFormat: readfiles.FULL_PATH}, function (err) {
-			if (err) console.log(util.inspect(err));
-		})
-		.then(files => {
-			files = files.sort();
-			for (var file of files) {
-				genStack.push(check(file,false,expectFailure));
-			}
-			genStackNext();
-		})
-		.catch(err => {
-			console.log(util.inspect(err));
-		});
-	}
+    if (pathspec.startsWith('@')) {
+        pathspec = pathspec.substr(1,pathspec.length-1);
+        var list = fs.readFileSync(pathspec,'utf8').split('\r').join('').split('\n');
+        for (var file of list) {
+            genStack.push(check(file,false,expectFailure));
+        }
+        genStackNext();
+    }
+    else if (fs.statSync(path.resolve(pathspec)).isFile()) {
+        genStack.push(check(pathspec,true,expectFailure));
+        genStackNext();
+    }
+    else {
+        readfiles(pathspec, {readContents: false, filenameFormat: readfiles.FULL_PATH}, function (err) {
+            if (err) console.log(util.inspect(err));
+        })
+        .then(files => {
+            files = files.sort();
+            for (var file of files) {
+                genStack.push(check(file,false,expectFailure));
+            }
+            genStackNext();
+        })
+        .catch(err => {
+            console.log(util.inspect(err));
+        });
+    }
 }
 
 process.exitCode = 1;
 console.log('Gathering...');
 if ((!argv._.length) && (!argv.fail)) {
-	argv._.push('../openapi-directory/APIs/');
+    argv._.push('../openapi-directory/APIs/');
 }
 for (let pathspec of argv._) {
-	processPathSpec(pathspec,false);
+    processPathSpec(pathspec,false);
 }
 if (argv.fail) {
-	if (!Array.isArray(argv.fail)) argv.fail = [argv.fail];
-	for (let pathspec of argv.fail) {
-		processPathSpec(pathspec,true);
-	}
+    if (!Array.isArray(argv.fail)) argv.fail = [argv.fail];
+    for (let pathspec of argv.fail) {
+        processPathSpec(pathspec,true);
+    }
 }
 
 process.on('exit', function() {
-	if (warnings.length) {
-		warnings.sort();
-		console.log(normal+'\nWarnings:'+yellow);
-		for (var w in warnings) {
-			console.log(warnings[w]);
-		}
-	}
-	if (failures.length) {
-		failures.sort();
-		console.log(normal+'\nFailures:'+red);
-		for (var f in failures) {
-			console.log(failures[f]);
-		}
-	}
-	console.log(normal);
-	console.log('Tests: %s passing, %s failing, %s warnings', pass, fail, warnings.length);
-	process.exitCode = ((fail === 0) && (pass > 0)) ? 0 : 1;
+    if (warnings.length) {
+        warnings.sort();
+        console.log(normal+'\nWarnings:'+yellow);
+        for (var w in warnings) {
+            console.log(warnings[w]);
+        }
+    }
+    if (failures.length) {
+        failures.sort();
+        console.log(normal+'\nFailures:'+red);
+        for (var f in failures) {
+            console.log(failures[f]);
+        }
+    }
+    console.log(normal);
+    console.log('Tests: %s passing, %s failing, %s warnings', pass, fail, warnings.length);
+    process.exitCode = ((fail === 0) && (pass > 0)) ? 0 : 1;
 });

--- a/validate.js
+++ b/validate.js
@@ -9,13 +9,13 @@ var util = require('util');
 var yaml = require('js-yaml');
 var should = require('should');
 var ajv = require('ajv')({
-	allErrors: true,
-	verbose: true,
-	jsonPointers: true,
-	patternGroups: true,
-	extendRefs: true // optional, current default is to 'fail', spec behaviour is to 'ignore'
+    allErrors: true,
+    verbose: true,
+    jsonPointers: true,
+    patternGroups: true,
+    extendRefs: true // optional, current default is to 'fail', spec behaviour is to 'ignore'
 });
-	//meta: false, // optional, to prevent adding draft-06 meta-schema
+    //meta: false, // optional, to prevent adding draft-06 meta-schema
 
 var ajvFormats = require('ajv/lib/compile/formats.js');
 ajv.addFormat('uriref',ajvFormats.full['uri-reference']);
@@ -34,431 +34,431 @@ var openapi3Schema = require('./schemas/openapi-3.0.json');
 var validateOpenAPI3 = ajv.compile(openapi3Schema);
 
 function contextAppend(options,s) {
-	options.context.push((options.context[options.context.length-1]+'/'+s).split('//').join('/'));
+    options.context.push((options.context[options.context.length-1]+'/'+s).split('//').join('/'));
 }
 
 function validateUrl(s,contextServers,context,options) {
-	if (!options.laxurls) s.should.not.be.exactly('','Invalid empty URL '+context);
-	var base = options.origin||'http://localhost/';
-	if (contextServers && contextServers.length) {
-		let servers = contextServers[0];
-		if (servers.length) {
-			base = servers[0].url;
-		}
-	}
-	if (s.indexOf('://')>0) { // FIXME HACK
-		base = undefined;
-	}
-	var u = (URL && options.whatwg) ? new URL(s,base) : url.parse(s);
-	return true; // if we haven't thrown
+    if (!options.laxurls) s.should.not.be.exactly('','Invalid empty URL '+context);
+    var base = options.origin||'http://localhost/';
+    if (contextServers && contextServers.length) {
+        let servers = contextServers[0];
+        if (servers.length) {
+            base = servers[0].url;
+        }
+    }
+    if (s.indexOf('://')>0) { // FIXME HACK
+        base = undefined;
+    }
+    var u = (URL && options.whatwg) ? new URL(s,base) : url.parse(s);
+    return true; // if we haven't thrown
 }
 
 function validateComponentName(name) {
-	return /^[a-zA-Z0-9\.\-_]+$/.test(name);
+    return /^[a-zA-Z0-9\.\-_]+$/.test(name);
 }
 
 function validateHeaderName(name) {
-	return /^[A-Za-z0-9!#\-\$%&'\*\+\\\.\^_`\|~]+$/.test(name);
+    return /^[A-Za-z0-9!#\-\$%&'\*\+\\\.\^_`\|~]+$/.test(name);
 }
 
 function validateSchema(schema,openapi,options) {
-	validateMetaSchema(schema);
-	var errors = validateSchema.errors;
-	if (errors && errors.length) {
-		throw(new Error('Schema invalid: '+util.inspect(errors)));
-	}
-	if (schema.externalDocs) {
-		schema.externalDocs.should.have.key('url');
-		schema.externalDocs.url.should.have.type('string');
-		validateUrl(schema.externalDocs.url,[openapi.servers],'externalDocs',options).should.not.throw();
-	}
-	return !(errors && errors.length);
+    validateMetaSchema(schema);
+    var errors = validateSchema.errors;
+    if (errors && errors.length) {
+        throw(new Error('Schema invalid: '+util.inspect(errors)));
+    }
+    if (schema.externalDocs) {
+        schema.externalDocs.should.have.key('url');
+        schema.externalDocs.url.should.have.type('string');
+        validateUrl(schema.externalDocs.url,[openapi.servers],'externalDocs',options).should.not.throw();
+    }
+    return !(errors && errors.length);
 }
 
 function checkContent(content,contextServers,openapi,options) {
-	contextAppend(options,'content');
-	for (let ct in content) {
-		contextAppend(options,jptr.jpescape(ct));
-		var contentType = content[ct];
-		should(contentType).be.an.Object();
-		should(contentType).not.be.an.Array();
-		if (typeof contentType.schema !== 'undefined') {
-			contentType.schema.should.be.an.Object();
-			contentType.schema.should.not.be.an.Array();
-		}
-		if (contentType.example) {
-			contentType.should.not.have.property('examples');
-		}
-		if (contentType.examples) {
-			contextAppend(options,'examples');
-			contentType.should.not.have.property('example');
-			contentType.examples.should.be.an.Object();
-			contentType.examples.should.not.be.an.Array();
-			for (let ex in contentType.examples) {
-				contentType.examples[ex].should.be.an.Object();
-				contentType.examples[ex].should.not.be.an.Array();
-				if (typeof contentType.examples[ex].summary !== 'undefined') {
-					contentType.examples[ex].summary.should.have.type('string');
-				}
-				if (typeof contentType.examples[ex].description !== 'undefined') {
-					contentType.examples[ex].description.should.have.type('string');
-				}
-				if (typeof contentType.examples[ex].value !== 'undefined') {
-					contentType.examples[ex].should.not.have.property('externalValue');
-				}
-				if (typeof contentType.examples[ex].externalValue !== 'undefined') {
-					contentType.examples[ex].externalValue.should.have.type('string');
-					contentType.examples[ex].should.not.have.property('value');
-					(function(){validateUrl(contentType.examples[ex].externalValue,contextServers,'examples..externalValue',options)}).should.not.throw();
-				}
+    contextAppend(options,'content');
+    for (let ct in content) {
+        contextAppend(options,jptr.jpescape(ct));
+        var contentType = content[ct];
+        should(contentType).be.an.Object();
+        should(contentType).not.be.an.Array();
+        if (typeof contentType.schema !== 'undefined') {
+            contentType.schema.should.be.an.Object();
+            contentType.schema.should.not.be.an.Array();
+        }
+        if (contentType.example) {
+            contentType.should.not.have.property('examples');
+        }
+        if (contentType.examples) {
+            contextAppend(options,'examples');
+            contentType.should.not.have.property('example');
+            contentType.examples.should.be.an.Object();
+            contentType.examples.should.not.be.an.Array();
+            for (let ex in contentType.examples) {
+                contentType.examples[ex].should.be.an.Object();
+                contentType.examples[ex].should.not.be.an.Array();
+                if (typeof contentType.examples[ex].summary !== 'undefined') {
+                    contentType.examples[ex].summary.should.have.type('string');
+                }
+                if (typeof contentType.examples[ex].description !== 'undefined') {
+                    contentType.examples[ex].description.should.have.type('string');
+                }
+                if (typeof contentType.examples[ex].value !== 'undefined') {
+                    contentType.examples[ex].should.not.have.property('externalValue');
+                }
+                if (typeof contentType.examples[ex].externalValue !== 'undefined') {
+                    contentType.examples[ex].externalValue.should.have.type('string');
+                    contentType.examples[ex].should.not.have.property('value');
+                    (function(){validateUrl(contentType.examples[ex].externalValue,contextServers,'examples..externalValue',options)}).should.not.throw();
+                }
 
-			}
-			options.context.pop();
-		}
-		if (contentType.schema) validateSchema(contentType.schema,openapi,options);
-		options.context.pop();
-	}
-	options.context.pop();
+            }
+            options.context.pop();
+        }
+        if (contentType.schema) validateSchema(contentType.schema,openapi,options);
+        options.context.pop();
+    }
+    options.context.pop();
 }
 
 function checkServer(server,options) {
-	server.should.have.property('url');
-	(function(){validateUrl(server.url,[],'server.url',options)}).should.not.throw();
-	let srvVars = 0;
-	server.url.replace(/\{(.+?)\}/g,function(match,group1) {
-		srvVars++;
-		server.should.have.key('variables');
-		server.variables.should.have.key(group1);
-	});
-	if (server.variables) {
-		contextAppend(options,'variables');
-		for (let v in server.variables) {
-			contextAppend(options,v);
-			server.variables[v].should.have.key('default');
-			server.variables[v].default.should.be.type('string');
-			if (typeof server.variables[v].enum !== 'undefined') {
-				contextAppend(options,'enum');
-				server.variables[v].enum.should.be.an.Array();
-				should(server.variables[v].enum.length).not.be.exactly(0,'Server variables enum should not be empty');
-				for (let e in server.variables[v].enum) {
-					contextAppend(options,e);
-					server.variables[v].enum[e].should.be.type('string');
-					options.context.pop();
-				}
-				options.context.pop();
-			}
-			options.context.pop();
-		}
-		should(Object.keys(server.variables).length).be.exactly(srvVars);
-		options.context.pop();
-	}
+    server.should.have.property('url');
+    (function(){validateUrl(server.url,[],'server.url',options)}).should.not.throw();
+    let srvVars = 0;
+    server.url.replace(/\{(.+?)\}/g,function(match,group1) {
+        srvVars++;
+        server.should.have.key('variables');
+        server.variables.should.have.key(group1);
+    });
+    if (server.variables) {
+        contextAppend(options,'variables');
+        for (let v in server.variables) {
+            contextAppend(options,v);
+            server.variables[v].should.have.key('default');
+            server.variables[v].default.should.be.type('string');
+            if (typeof server.variables[v].enum !== 'undefined') {
+                contextAppend(options,'enum');
+                server.variables[v].enum.should.be.an.Array();
+                should(server.variables[v].enum.length).not.be.exactly(0,'Server variables enum should not be empty');
+                for (let e in server.variables[v].enum) {
+                    contextAppend(options,e);
+                    server.variables[v].enum[e].should.be.type('string');
+                    options.context.pop();
+                }
+                options.context.pop();
+            }
+            options.context.pop();
+        }
+        should(Object.keys(server.variables).length).be.exactly(srvVars);
+        options.context.pop();
+    }
 }
 
 function checkServers(servers,options) {
-	servers.should.be.an.Array();
-	for (let s in servers) {
-		contextAppend(options,s);
-		let server = servers[s];
-		checkServer(server,options);
-		options.context.pop();
-	}
+    servers.should.be.an.Array();
+    for (let s in servers) {
+        contextAppend(options,s);
+        let server = servers[s];
+        checkServer(server,options);
+        options.context.pop();
+    }
 }
 
 function checkLink(link,options) {
-	link.should.be.type('object');
-	if (typeof link.operationRef !== 'undefined') {
-		link.operationRef.should.be.type('string');
-		link.should.not.have.property('operationId');
-	}
-	if (typeof link.operationId !== 'undefined') {
-		link.operationId.should.be.type('string');
-		link.should.not.have.property('operationRef');
-		// validate operationId exists (external refs?)
-	}
-	if (typeof link.parameters != 'undefined') {
-		link.parameters.should.be.type('object');
-		link.parameters.should.not.be.an.Array();
-	}
-	if (typeof link.description !== 'undefined') {
-		link.description.should.have.type('string');
-	}
-	if (typeof link.server !== 'undefined') {
-		checkServer(link.server,options);
-	}
+    link.should.be.type('object');
+    if (typeof link.operationRef !== 'undefined') {
+        link.operationRef.should.be.type('string');
+        link.should.not.have.property('operationId');
+    }
+    if (typeof link.operationId !== 'undefined') {
+        link.operationId.should.be.type('string');
+        link.should.not.have.property('operationRef');
+        // validate operationId exists (external refs?)
+    }
+    if (typeof link.parameters != 'undefined') {
+        link.parameters.should.be.type('object');
+        link.parameters.should.not.be.an.Array();
+    }
+    if (typeof link.description !== 'undefined') {
+        link.description.should.have.type('string');
+    }
+    if (typeof link.server !== 'undefined') {
+        checkServer(link.server,options);
+    }
 }
 
 function checkHeader(header,contextServers,openapi,options) {
-	if (header.$ref) {
-		var ref = header.$ref;
-		should(Object.keys(header).length).be.exactly(1,'Reference object cannot be extended');
-		header = common.resolveInternal(openapi,ref);
-		should(header).not.be.exactly(false,'Could not resolve reference '+ref);
-	}
-	header.should.not.have.property('name');
-	header.should.not.have.property('in');
-	header.should.not.have.property('type');
-	for (let prop of common.parameterTypeProperties) {
-		header.should.not.have.property(prop);
-	}
-	if (header.schema) {
-		header.should.not.have.property('content');
-		if (typeof header.style !== 'undefined') {
-			header.style.should.be.type('string');
-			header.style.should.be.exactly('simple');
-		}
-		if (typeof header.explode !== 'undefined') {
-			header.explode.should.be.type('boolean');
-		}
-		if (typeof header.allowReserved !== 'undefined') {
-			header.allowReserved.should.be.type('boolean');
-		}
-		validateSchema(header.schema,openapi,options);
-	}
-	if (header.content) {
-		header.should.not.have.property('schema');
-		header.should.not.have.property('style');
-		header.should.not.have.property('explode');
-		header.should.not.have.property('allowReserved');
-		header.should.not.have.property('example');
-		header.should.not.have.property('examples');
-		checkContent(header.content,contextServers,openapi,options);
-	}
-	if (!header.schema && !header.content) {
-		header.should.have.property('schema','Header should have schema or content');
-	}
+    if (header.$ref) {
+        var ref = header.$ref;
+        should(Object.keys(header).length).be.exactly(1,'Reference object cannot be extended');
+        header = common.resolveInternal(openapi,ref);
+        should(header).not.be.exactly(false,'Could not resolve reference '+ref);
+    }
+    header.should.not.have.property('name');
+    header.should.not.have.property('in');
+    header.should.not.have.property('type');
+    for (let prop of common.parameterTypeProperties) {
+        header.should.not.have.property(prop);
+    }
+    if (header.schema) {
+        header.should.not.have.property('content');
+        if (typeof header.style !== 'undefined') {
+            header.style.should.be.type('string');
+            header.style.should.be.exactly('simple');
+        }
+        if (typeof header.explode !== 'undefined') {
+            header.explode.should.be.type('boolean');
+        }
+        if (typeof header.allowReserved !== 'undefined') {
+            header.allowReserved.should.be.type('boolean');
+        }
+        validateSchema(header.schema,openapi,options);
+    }
+    if (header.content) {
+        header.should.not.have.property('schema');
+        header.should.not.have.property('style');
+        header.should.not.have.property('explode');
+        header.should.not.have.property('allowReserved');
+        header.should.not.have.property('example');
+        header.should.not.have.property('examples');
+        checkContent(header.content,contextServers,openapi,options);
+    }
+    if (!header.schema && !header.content) {
+        header.should.have.property('schema','Header should have schema or content');
+    }
 }
 
 function checkResponse(response,contextServers,openapi,options) {
-	if (response.$ref) {
-		var ref = response.$ref;
-		should(Object.keys(response).length).be.exactly(1,'Reference object cannot be extended');
-		response = common.resolveInternal(openapi,ref);
-		should(response).not.be.exactly(false,'Could not resolve reference '+ref);
-	}
-	response.should.have.property('description');
-	should(response.description).have.type('string','response description should be of type string');
-	response.should.not.have.property('examples');
-	if (typeof response.schema !== 'undefined') {
-		response.schema.should.be.an.Object();
-		response.schema.should.not.be.an.Array();
-	}
-	if (response.headers) {
-		contextAppend(options,'headers');
-		for (let h in response.headers) {
-			contextAppend(options,h);
-			validateHeaderName(h).should.be.equal(true,'Header doesn\'t match RFC7230 pattern');
-			checkHeader(response.headers[h],contextServers,openapi,options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (response.$ref) {
+        var ref = response.$ref;
+        should(Object.keys(response).length).be.exactly(1,'Reference object cannot be extended');
+        response = common.resolveInternal(openapi,ref);
+        should(response).not.be.exactly(false,'Could not resolve reference '+ref);
+    }
+    response.should.have.property('description');
+    should(response.description).have.type('string','response description should be of type string');
+    response.should.not.have.property('examples');
+    if (typeof response.schema !== 'undefined') {
+        response.schema.should.be.an.Object();
+        response.schema.should.not.be.an.Array();
+    }
+    if (response.headers) {
+        contextAppend(options,'headers');
+        for (let h in response.headers) {
+            contextAppend(options,h);
+            validateHeaderName(h).should.be.equal(true,'Header doesn\'t match RFC7230 pattern');
+            checkHeader(response.headers[h],contextServers,openapi,options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (response.content) {
-		checkContent(response.content,contextServers,openapi,options);
-	}
+    if (response.content) {
+        checkContent(response.content,contextServers,openapi,options);
+    }
 
-	if (typeof response.links !== 'undefined') {
-		contextAppend(options,'links');
-		for (let l in response.links) {
-			contextAppend(options,l);
-			checkLink(response.links[l],options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (typeof response.links !== 'undefined') {
+        contextAppend(options,'links');
+        for (let l in response.links) {
+            contextAppend(options,l);
+            checkLink(response.links[l],options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 }
 
 function checkParam(param,index,contextServers,openapi,options){
-	contextAppend(options,index);
-	if (param.$ref) {
-		should(Object.keys(param).length).be.exactly(1,'Reference object cannot be extended');
-		var ref = param.$ref;
-		param = common.resolveInternal(openapi,ref);
-		should(param).not.be.exactly(false,'Could not resolve reference '+ref);
-	}
-	param.should.have.property('name');
-	param.name.should.have.type('string');
-	param.should.have.property('in');
-	param.in.should.have.type('string');
-	param.in.should.equalOneOf('query','header','path','cookie');
-	if (param.in == 'path') {
-		param.should.have.property('required');
-		param.required.should.be.exactly(true,'Path parameters must have an explicit required:true');
-	}
-	if (typeof param.required !== 'undefined') should(param.required).have.type('boolean');
-	param.should.not.have.property('items');
-	param.should.not.have.property('collectionFormat');
-	param.should.not.have.property('type');
-	for (let prop of common.parameterTypeProperties) {
-		param.should.not.have.property(prop);
-	}
-	param.in.should.not.be.exactly('body','Parameter type body is no-longer valid');
-	param.in.should.not.be.exactly('formData','Parameter type formData is no-longer valid');
-	if (param.description) {
-		param.description.should.have.type('string');
-	}
-	if (param.schema) {
-		param.should.not.have.property('content');
-		if (typeof param.style !== 'undefined') {
-			param.style.should.be.type('string');
-			if (param.in == 'path') {
-				param.style.should.not.be.exactly('form');
-				param.style.should.not.be.exactly('spaceDelimited');
-				param.style.should.not.be.exactly('pipeDelimited');
-				param.style.should.not.be.exactly('deepObject');
-			}
-			if (param.in == 'query') {
-				param.style.should.not.be.exactly('matrix');
-				param.style.should.not.be.exactly('label');
-				param.style.should.not.be.exactly('simple');
-			}
-			if (param.in == 'header') {
-				param.style.should.be.exactly('simple');
-			}
-			if (param.in == 'cookie') {
-				param.style.should.be.exactly('form');
-			}
-		}
-		if (typeof param.explode !== 'undefined') {
-			param.explode.should.be.type('boolean');
-		}
-		if (typeof param.allowReserved !== 'undefined') {
-			param.allowReserved.should.be.type('boolean');
-		}
-		validateSchema(param.schema,openapi,options);
-	}
-	if (param.content) {
-		param.should.not.have.property('schema');
-		param.should.not.have.property('style');
-		param.should.not.have.property('explode');
-		param.should.not.have.property('allowReserved');
-		param.should.not.have.property('example');
-		param.should.not.have.property('examples');
-		should(Object.keys(param.content).length).be.exactly(1,'Parameter content must have only one entry');
-		checkContent(param.content,contextServers,openapi,options);
-	}
-	if (!param.schema && !param.content) {
-		param.should.have.property('schema','Parameter should have schema or content');
-	}
-	options.context.pop();
-	return true;
+    contextAppend(options,index);
+    if (param.$ref) {
+        should(Object.keys(param).length).be.exactly(1,'Reference object cannot be extended');
+        var ref = param.$ref;
+        param = common.resolveInternal(openapi,ref);
+        should(param).not.be.exactly(false,'Could not resolve reference '+ref);
+    }
+    param.should.have.property('name');
+    param.name.should.have.type('string');
+    param.should.have.property('in');
+    param.in.should.have.type('string');
+    param.in.should.equalOneOf('query','header','path','cookie');
+    if (param.in == 'path') {
+        param.should.have.property('required');
+        param.required.should.be.exactly(true,'Path parameters must have an explicit required:true');
+    }
+    if (typeof param.required !== 'undefined') should(param.required).have.type('boolean');
+    param.should.not.have.property('items');
+    param.should.not.have.property('collectionFormat');
+    param.should.not.have.property('type');
+    for (let prop of common.parameterTypeProperties) {
+        param.should.not.have.property(prop);
+    }
+    param.in.should.not.be.exactly('body','Parameter type body is no-longer valid');
+    param.in.should.not.be.exactly('formData','Parameter type formData is no-longer valid');
+    if (param.description) {
+        param.description.should.have.type('string');
+    }
+    if (param.schema) {
+        param.should.not.have.property('content');
+        if (typeof param.style !== 'undefined') {
+            param.style.should.be.type('string');
+            if (param.in == 'path') {
+                param.style.should.not.be.exactly('form');
+                param.style.should.not.be.exactly('spaceDelimited');
+                param.style.should.not.be.exactly('pipeDelimited');
+                param.style.should.not.be.exactly('deepObject');
+            }
+            if (param.in == 'query') {
+                param.style.should.not.be.exactly('matrix');
+                param.style.should.not.be.exactly('label');
+                param.style.should.not.be.exactly('simple');
+            }
+            if (param.in == 'header') {
+                param.style.should.be.exactly('simple');
+            }
+            if (param.in == 'cookie') {
+                param.style.should.be.exactly('form');
+            }
+        }
+        if (typeof param.explode !== 'undefined') {
+            param.explode.should.be.type('boolean');
+        }
+        if (typeof param.allowReserved !== 'undefined') {
+            param.allowReserved.should.be.type('boolean');
+        }
+        validateSchema(param.schema,openapi,options);
+    }
+    if (param.content) {
+        param.should.not.have.property('schema');
+        param.should.not.have.property('style');
+        param.should.not.have.property('explode');
+        param.should.not.have.property('allowReserved');
+        param.should.not.have.property('example');
+        param.should.not.have.property('examples');
+        should(Object.keys(param.content).length).be.exactly(1,'Parameter content must have only one entry');
+        checkContent(param.content,contextServers,openapi,options);
+    }
+    if (!param.schema && !param.content) {
+        param.should.have.property('schema','Parameter should have schema or content');
+    }
+    options.context.pop();
+    return true;
 }
 
 function checkPathItem(pathItem,openapi,options) {
 
-	var contextServers = [];
-	contextServers.push(openapi.servers);
-	if (pathItem.servers) contextServers.push(pathItem.servers);
+    var contextServers = [];
+    contextServers.push(openapi.servers);
+    if (pathItem.servers) contextServers.push(pathItem.servers);
 
-	for (let o in pathItem) {
-		contextAppend(options,o);
-		var op = pathItem[o];
-		if (o == 'parameters') {
-			for (let p in pathItem.parameters) {
-				checkParam(pathItem.parameters[p],p,contextServers,openapi,options);
-			}
-		}
-		else if (o == 'servers') {
-			contextAppend(options,'servers');
-			checkServers(op,options); // won't be here in converted definitions
-			options.context.pop();
-		}
-		else if (o == 'summary') {
-			pathItem.summary.should.have.type('string');
-		}
-		else if (o == 'description') {
-			pathItem.description.should.have.type('string');
-		}
-		else if (common.httpVerbs.indexOf(o)>=0) {
-			op.should.not.be.empty();
-			op.should.not.have.property('consumes');
-			op.should.not.have.property('produces');
-			op.should.not.have.property('schemes');
-			op.should.have.property('responses');
-			op.responses.should.not.be.empty();
-			if (op.summary) op.summary.should.have.type('string');
-			if (op.description) op.description.should.have.type('string');
+    for (let o in pathItem) {
+        contextAppend(options,o);
+        var op = pathItem[o];
+        if (o == 'parameters') {
+            for (let p in pathItem.parameters) {
+                checkParam(pathItem.parameters[p],p,contextServers,openapi,options);
+            }
+        }
+        else if (o == 'servers') {
+            contextAppend(options,'servers');
+            checkServers(op,options); // won't be here in converted definitions
+            options.context.pop();
+        }
+        else if (o == 'summary') {
+            pathItem.summary.should.have.type('string');
+        }
+        else if (o == 'description') {
+            pathItem.description.should.have.type('string');
+        }
+        else if (common.httpVerbs.indexOf(o)>=0) {
+            op.should.not.be.empty();
+            op.should.not.have.property('consumes');
+            op.should.not.have.property('produces');
+            op.should.not.have.property('schemes');
+            op.should.have.property('responses');
+            op.responses.should.not.be.empty();
+            if (op.summary) op.summary.should.have.type('string');
+            if (op.description) op.description.should.have.type('string');
 
-			if (op.servers) {
-				contextAppend(options,'servers');
-				checkServers(op.servers,options); // won't be here in converted definitions
-				options.context.pop();
-				contextServers.push(op.servers);
-			}
+            if (op.servers) {
+                contextAppend(options,'servers');
+                checkServers(op.servers,options); // won't be here in converted definitions
+                options.context.pop();
+                contextServers.push(op.servers);
+            }
 
-			if (op.requestBody && op.requestBody.content) {
-				contextAppend(options,'requestBody');
-				op.requestBody.should.have.property('content');
-				if (typeof op.requestBody.description !== 'undefined') should(op.requestBody.description).have.type('string');
-				if (typeof op.requestBody.required !== 'undefined') op.requestBody.required.should.have.type('boolean');
-				checkContent(op.requestBody.content,contextServers,openapi,options);
-				options.context.pop();
-			}
+            if (op.requestBody && op.requestBody.content) {
+                contextAppend(options,'requestBody');
+                op.requestBody.should.have.property('content');
+                if (typeof op.requestBody.description !== 'undefined') should(op.requestBody.description).have.type('string');
+                if (typeof op.requestBody.required !== 'undefined') op.requestBody.required.should.have.type('boolean');
+                checkContent(op.requestBody.content,contextServers,openapi,options);
+                options.context.pop();
+            }
 
-			contextAppend(options,'responses');
-			for (let r in op.responses) {
-				contextAppend(options,r);
-				var response = op.responses[r];
-				checkResponse(response,contextServers,openapi,options);
-				options.context.pop();
-			}
-			options.context.pop();
+            contextAppend(options,'responses');
+            for (let r in op.responses) {
+                contextAppend(options,r);
+                var response = op.responses[r];
+                checkResponse(response,contextServers,openapi,options);
+                options.context.pop();
+            }
+            options.context.pop();
 
-			if (op.parameters) {
-				contextAppend(options,'parameters');
-				for (let p in op.parameters) {
-					checkParam(op.parameters[p],p,contextServers,openapi,options);
-				}
-				options.context.pop();
-			}
-			if (op.externalDocs) {
-				contextAppend(options,'externalDocs');
-				op.externalDocs.should.have.key('url');
-				op.externalDocs.url.should.have.type('string');
-				(function(){validateUrl(op.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
-				options.context.pop();
-			}
-			if (op.callbacks) {
-				contextAppend(options,'callbacks');
-				for (let c in op.callbacks) {
-					let callback = op.callbacks[c];
-					if (!callback.$ref) {
-						contextAppend(options,c);
-						for (let p in callback) {
-							let cbPi = callback[p];
-							checkPathItem(cbPi,openapi,options);
-						}
-						options.context.pop();
-					}
-				}
-				options.context.pop();
-			}
-		}
-		options.context.pop();
-	}
-	return true;
+            if (op.parameters) {
+                contextAppend(options,'parameters');
+                for (let p in op.parameters) {
+                    checkParam(op.parameters[p],p,contextServers,openapi,options);
+                }
+                options.context.pop();
+            }
+            if (op.externalDocs) {
+                contextAppend(options,'externalDocs');
+                op.externalDocs.should.have.key('url');
+                op.externalDocs.url.should.have.type('string');
+                (function(){validateUrl(op.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
+                options.context.pop();
+            }
+            if (op.callbacks) {
+                contextAppend(options,'callbacks');
+                for (let c in op.callbacks) {
+                    let callback = op.callbacks[c];
+                    if (!callback.$ref) {
+                        contextAppend(options,c);
+                        for (let p in callback) {
+                            let cbPi = callback[p];
+                            checkPathItem(cbPi,openapi,options);
+                        }
+                        options.context.pop();
+                    }
+                }
+                options.context.pop();
+            }
+        }
+        options.context.pop();
+    }
+    return true;
 }
 
 function validateSync(openapi, options, callback) {
-	options.valid = false;
-	options.context = [];
-	options.warnings = [];
+    options.valid = false;
+    options.context = [];
+    options.warnings = [];
 
-	if (options.jsonschema) {
-		let schemaStr = fs.readFileSync(options.jsonschema,'utf8');
-		openapi3Schema = yaml.safeLoad(schemaStr,{json:true});
-		validateOpenAPI3 = ajv.compile(openapi3Schema);
-	}
+    if (options.jsonschema) {
+        let schemaStr = fs.readFileSync(options.jsonschema,'utf8');
+        openapi3Schema = yaml.safeLoad(schemaStr,{json:true});
+        validateOpenAPI3 = ajv.compile(openapi3Schema);
+    }
 
-	options.context.push('#/');
+    options.context.push('#/');
     openapi.should.not.have.key('swagger');
-	openapi.should.have.key('openapi');
-	openapi.openapi.should.have.type('string');
-	should.ok(openapi.openapi.startsWith('3.0.'),'Must be an OpenAPI 3.0.x document');
-	openapi.should.not.have.key('host');
-	openapi.should.not.have.key('basePath');
-	openapi.should.not.have.key('schemes');
-	openapi.should.have.key('paths');
+    openapi.should.have.key('openapi');
+    openapi.openapi.should.have.type('string');
+    should.ok(openapi.openapi.startsWith('3.0.'),'Must be an OpenAPI 3.0.x document');
+    openapi.should.not.have.key('host');
+    openapi.should.not.have.key('basePath');
+    openapi.should.not.have.key('schemes');
+    openapi.should.have.key('paths');
     openapi.should.not.have.key('definitions');
     openapi.should.not.have.key('parameters');
     openapi.should.not.have.key('responses');
@@ -466,277 +466,277 @@ function validateSync(openapi, options, callback) {
     openapi.should.not.have.key('produces');
     openapi.should.not.have.key('consumes');
 
-	openapi.should.have.key('info');
-	contextAppend(options,'info');
-	openapi.info.should.have.key('title');
-	should(openapi.info.title).be.type('string','title should be of type string');
-	openapi.info.should.have.key('version');
-	should(openapi.info.version).be.type('string','version should be of type string');
-	if (openapi.info.license) {
-		contextAppend(options,'license');
-		openapi.info.license.should.have.key('name');
-		openapi.info.license.name.should.have.type('string');
-		options.context.pop();
-	}
-	if (typeof openapi.info.termsOfService !== 'undefined') {
-		should(openapi.info.termsOfService).not.be.Null();
-		(function(){validateUrl(openapi.info.termsOfService,contextServers,'termsOfService',options)}).should.not.throw();
-	}
-	options.context.pop();
+    openapi.should.have.key('info');
+    contextAppend(options,'info');
+    openapi.info.should.have.key('title');
+    should(openapi.info.title).be.type('string','title should be of type string');
+    openapi.info.should.have.key('version');
+    should(openapi.info.version).be.type('string','version should be of type string');
+    if (openapi.info.license) {
+        contextAppend(options,'license');
+        openapi.info.license.should.have.key('name');
+        openapi.info.license.name.should.have.type('string');
+        options.context.pop();
+    }
+    if (typeof openapi.info.termsOfService !== 'undefined') {
+        should(openapi.info.termsOfService).not.be.Null();
+        (function(){validateUrl(openapi.info.termsOfService,contextServers,'termsOfService',options)}).should.not.throw();
+    }
+    options.context.pop();
 
-	var contextServers = [];
-	if (openapi.servers) {
-		contextAppend(options,'servers');
-		checkServers(openapi.servers,options);
-		options.context.pop();
-		contextServers.push(openapi.servers);
-	}
-	if (openapi.externalDocs) {
-		contextAppend(options,'externalDocs');
-		openapi.externalDocs.should.have.key('url');
-		openapi.externalDocs.url.should.have.type('string');
-		(function(){validateUrl(openapi.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
-		options.context.pop();
-	}
+    var contextServers = [];
+    if (openapi.servers) {
+        contextAppend(options,'servers');
+        checkServers(openapi.servers,options);
+        options.context.pop();
+        contextServers.push(openapi.servers);
+    }
+    if (openapi.externalDocs) {
+        contextAppend(options,'externalDocs');
+        openapi.externalDocs.should.have.key('url');
+        openapi.externalDocs.url.should.have.type('string');
+        (function(){validateUrl(openapi.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
+        options.context.pop();
+    }
 
-	if (openapi.tags) {
-		contextAppend(options,'tags');
-		for (let tag of openapi.tags) {
-			tag.should.have.property('name');
-			tag.name.should.have.type('string');
-			if (tag.externalDocs) {
-				tag.externalDocs.should.have.key('url');
-				tag.externalDocs.url.should.have.type('string');
-				(function(){validateUrl(tag.externalDocs.url,contextServers,'tag.externalDocs',options)}).should.not.throw();
-			}
-		}
-		options.context.pop();
-	}
+    if (openapi.tags) {
+        contextAppend(options,'tags');
+        for (let tag of openapi.tags) {
+            tag.should.have.property('name');
+            tag.name.should.have.type('string');
+            if (tag.externalDocs) {
+                tag.externalDocs.should.have.key('url');
+                tag.externalDocs.url.should.have.type('string');
+                (function(){validateUrl(tag.externalDocs.url,contextServers,'tag.externalDocs',options)}).should.not.throw();
+            }
+        }
+        options.context.pop();
+    }
 
     if (openapi.components && openapi.components.securitySchemes) {
         for (let s in openapi.components.securitySchemes) {
-			options.context.push('#/components/securitySchemes/'+s);
-			validateComponentName(s).should.be.equal(true,'component name invalid');
+            options.context.push('#/components/securitySchemes/'+s);
+            validateComponentName(s).should.be.equal(true,'component name invalid');
             var scheme = openapi.components.securitySchemes[s];
-			scheme.should.have.property('type');
-			scheme.type.should.have.type('string');
+            scheme.should.have.property('type');
+            scheme.type.should.have.type('string');
             scheme.type.should.not.be.exactly('basic','Security scheme basic should be http with scheme basic');
-			scheme.type.should.equalOneOf('apiKey','http','oauth2','openIdConnect');
-			if (scheme.type == 'http') {
-				scheme.should.have.property('scheme');
-				scheme.scheme.should.have.type('string');
-				if (scheme.scheme != 'bearer') {
-					scheme.should.not.have.property('bearerFormat');
-				}
-			}
-			else {
-				scheme.should.not.have.property('scheme');
-				scheme.should.not.have.property('bearerFormat');
-			}
-			if (scheme.type == 'apiKey') {
-				scheme.should.have.property('name');
-				scheme.name.should.have.type('string');
-				scheme.should.have.property('in');
-				scheme.in.should.have.type('string');
-				scheme.in.should.equalOneOf('query','header');
-			}
-			else {
-				scheme.should.not.have.property('name');
-				scheme.should.not.have.property('in');
-			}
-			if (scheme.type == 'oauth2') {
-				scheme.should.not.have.property('flow');
-				scheme.should.have.property('flows');
-				for (let f in scheme.flows) {
-					var flow = scheme.flows[f];
-					if ((f == 'implicit') || (f == 'authorizationCode')) {
-						flow.should.have.property('authorizationUrl');
-						flow.authorizationUrl.should.have.type('string');
-						(function(){validateUrl(flow.authorizationUrl,contextServers,'authorizationUrl',options)}).should.not.throw();
-					}
-					else {
-						flow.should.not.have.property('authorizationUrl');
-					}
-					if ((f == 'password') || (f == 'clientCredentials') ||
-						(f == 'authorizationCode')) {
-						flow.should.have.property('tokenUrl');
-						flow.tokenUrl.should.have.type('string');
-						(function(){validateUrl(flow.tokenUrl,contextServers,'tokenUrl',options)}).should.not.throw();
-					}
-					else {
-						flow.should.not.have.property('tokenUrl');
-					}
-					if (typeof flow.refreshUrl !== 'undefined') {
-						(function(){validateUrl(flow.refreshUrl,contextServers,'refreshUrl',options)}).should.not.throw();
-					}
-					flow.should.have.property('scopes');
-				}
-			}
-			else {
-				scheme.should.not.have.property('flows');
-			}
-			if (scheme.type == 'openIdConnect') {
-				scheme.should.have.property('openIdConnectUrl');
-				scheme.openIdConnectUrl.should.have.type('string');
-				(function(){validateUrl(scheme.openIdConnectUrl,contextServers,'openIdConnectUrl',options)}).should.not.throw();
-			}
-			else {
-				scheme.should.not.have.property('openIdConnectUrl');
-			}
-			options.context.pop();
+            scheme.type.should.equalOneOf('apiKey','http','oauth2','openIdConnect');
+            if (scheme.type == 'http') {
+                scheme.should.have.property('scheme');
+                scheme.scheme.should.have.type('string');
+                if (scheme.scheme != 'bearer') {
+                    scheme.should.not.have.property('bearerFormat');
+                }
+            }
+            else {
+                scheme.should.not.have.property('scheme');
+                scheme.should.not.have.property('bearerFormat');
+            }
+            if (scheme.type == 'apiKey') {
+                scheme.should.have.property('name');
+                scheme.name.should.have.type('string');
+                scheme.should.have.property('in');
+                scheme.in.should.have.type('string');
+                scheme.in.should.equalOneOf('query','header');
+            }
+            else {
+                scheme.should.not.have.property('name');
+                scheme.should.not.have.property('in');
+            }
+            if (scheme.type == 'oauth2') {
+                scheme.should.not.have.property('flow');
+                scheme.should.have.property('flows');
+                for (let f in scheme.flows) {
+                    var flow = scheme.flows[f];
+                    if ((f == 'implicit') || (f == 'authorizationCode')) {
+                        flow.should.have.property('authorizationUrl');
+                        flow.authorizationUrl.should.have.type('string');
+                        (function(){validateUrl(flow.authorizationUrl,contextServers,'authorizationUrl',options)}).should.not.throw();
+                    }
+                    else {
+                        flow.should.not.have.property('authorizationUrl');
+                    }
+                    if ((f == 'password') || (f == 'clientCredentials') ||
+                        (f == 'authorizationCode')) {
+                        flow.should.have.property('tokenUrl');
+                        flow.tokenUrl.should.have.type('string');
+                        (function(){validateUrl(flow.tokenUrl,contextServers,'tokenUrl',options)}).should.not.throw();
+                    }
+                    else {
+                        flow.should.not.have.property('tokenUrl');
+                    }
+                    if (typeof flow.refreshUrl !== 'undefined') {
+                        (function(){validateUrl(flow.refreshUrl,contextServers,'refreshUrl',options)}).should.not.throw();
+                    }
+                    flow.should.have.property('scopes');
+                }
+            }
+            else {
+                scheme.should.not.have.property('flows');
+            }
+            if (scheme.type == 'openIdConnect') {
+                scheme.should.have.property('openIdConnectUrl');
+                scheme.openIdConnectUrl.should.have.type('string');
+                (function(){validateUrl(scheme.openIdConnectUrl,contextServers,'openIdConnectUrl',options)}).should.not.throw();
+            }
+            else {
+                scheme.should.not.have.property('openIdConnectUrl');
+            }
+            options.context.pop();
         }
     }
 
     common.recurse(openapi,null,function(obj,key,state){
         if ((key === '$ref') && (typeof obj[key] === 'string')) {
-			options.context.push(state.path);
+            options.context.push(state.path);
             obj[key].should.not.startWith('#/definitions/');
-			should(Object.keys(obj).length).be.exactly(1,'Reference object cannot be extended');
-			var refUrl = url.parse(obj[key]);
-			if (!refUrl.protocol && !refUrl.path) {
-				should(jptr.jptr(openapi,obj[key])).not.be.exactly(false,'Cannot resolve reference: '+obj[key]);
-			}
-			options.context.pop();
+            should(Object.keys(obj).length).be.exactly(1,'Reference object cannot be extended');
+            var refUrl = url.parse(obj[key]);
+            if (!refUrl.protocol && !refUrl.path) {
+                should(jptr.jptr(openapi,obj[key])).not.be.exactly(false,'Cannot resolve reference: '+obj[key]);
+            }
+            options.context.pop();
         }
     });
 
     for (let p in openapi.paths) {
-		options.context.push('#/paths/'+jptr.jpescape(p));
-		if (!p.startsWith('x-')) {
-			p.should.startWith('/');
-			checkPathItem(openapi.paths[p],openapi,options);
-		}
-		options.context.pop();
+        options.context.push('#/paths/'+jptr.jpescape(p));
+        if (!p.startsWith('x-')) {
+            p.should.startWith('/');
+            checkPathItem(openapi.paths[p],openapi,options);
+        }
+        options.context.pop();
     }
     if (openapi["x-ms-paths"]) {
         for (let p in openapi["x-ms-paths"]) {
-			options.context.push('#/x-ms-paths/'+jptr.jpescape(p));
-			p.should.startWith('/');
+            options.context.push('#/x-ms-paths/'+jptr.jpescape(p));
+            p.should.startWith('/');
             checkPathItem(openapi["x-ms-paths"][p],openapi,options);
-			options.context.pop();
+            options.context.pop();
         }
     }
 
     if (openapi.components && openapi.components.parameters) {
-		options.context.push('#/components/parameters/');
+        options.context.push('#/components/parameters/');
         for (let p in openapi.components.parameters) {
             checkParam(openapi.components.parameters[p],p,contextServers,openapi,options);
-			contextAppend(options, p);
-			validateComponentName(p).should.be.equal(true,'component name invalid');
-			options.context.pop();
+            contextAppend(options, p);
+            validateComponentName(p).should.be.equal(true,'component name invalid');
+            options.context.pop();
         }
-		options.context.pop();
+        options.context.pop();
     }
 
-	if (openapi.components && openapi.components.schemas) {
-		options.context.push('#/components/schemas');
-		openapi.components.schemas.should.be.type('object');
-		openapi.components.schemas.should.not.be.an.Array();
-		for (let s in openapi.components.schemas) {
-			options.context.push('#/components/schemas/'+s);
-			validateComponentName(s).should.be.equal(true,'component name invalid');
-			validateSchema(openapi.components.schemas[s],openapi,options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.schemas) {
+        options.context.push('#/components/schemas');
+        openapi.components.schemas.should.be.type('object');
+        openapi.components.schemas.should.not.be.an.Array();
+        for (let s in openapi.components.schemas) {
+            options.context.push('#/components/schemas/'+s);
+            validateComponentName(s).should.be.equal(true,'component name invalid');
+            validateSchema(openapi.components.schemas[s],openapi,options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (openapi.components && openapi.components.responses) {
-		options.context.push('#/components/responses');
-		openapi.components.responses.should.be.type('object');
-		openapi.components.responses.should.not.be.an.Array();
-		for (let r in openapi.components.responses) {
-			options.context.push('#/components/responses/'+r);
-			validateComponentName(r).should.be.equal(true,'component name invalid');
-			checkResponse(openapi.components.responses[r],contextServers,openapi,options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.responses) {
+        options.context.push('#/components/responses');
+        openapi.components.responses.should.be.type('object');
+        openapi.components.responses.should.not.be.an.Array();
+        for (let r in openapi.components.responses) {
+            options.context.push('#/components/responses/'+r);
+            validateComponentName(r).should.be.equal(true,'component name invalid');
+            checkResponse(openapi.components.responses[r],contextServers,openapi,options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (openapi.components && openapi.components.headers) {
-		options.context.push('#/components/headers');
-		openapi.components.headers.should.be.type('object');
-		openapi.components.headers.should.not.be.an.Array();
-		for (let h in openapi.components.headers) {
-			options.context.push('#/components/headers/'+h);
-			validateComponentName(h).should.be.equal(true,'component name invalid');
-			checkHeader(openapi.components.headers[h],contextServers,openapi,options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.headers) {
+        options.context.push('#/components/headers');
+        openapi.components.headers.should.be.type('object');
+        openapi.components.headers.should.not.be.an.Array();
+        for (let h in openapi.components.headers) {
+            options.context.push('#/components/headers/'+h);
+            validateComponentName(h).should.be.equal(true,'component name invalid');
+            checkHeader(openapi.components.headers[h],contextServers,openapi,options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (openapi.components && openapi.components.requestBodies) {
-		options.context.push('#/components/requestBodies');
-		openapi.components.requestBodies.should.be.type('object');
-		openapi.components.requestBodies.should.not.be.an.Array();
-		for (let r in openapi.components.requestBodies) {
-			options.context.push('#/components/requestBodies/'+r);
-			validateComponentName(r).should.be.equal(true,'component name invalid');
-			if (r.startsWith('requestBody')) {
-				options.warnings.push('Anonymous requestBody: '+r);
-			}
-			let rb = openapi.components.requestBodies[r];
-			rb.should.have.property('content');
-			if (typeof rb.description !== 'undefined') should(rb.description).have.type('string');
-			if (typeof rb.required !== 'undefined') rb.required.should.have.type('boolean');
-			checkContent(rb.content,openapi.servers,openapi,options);
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.requestBodies) {
+        options.context.push('#/components/requestBodies');
+        openapi.components.requestBodies.should.be.type('object');
+        openapi.components.requestBodies.should.not.be.an.Array();
+        for (let r in openapi.components.requestBodies) {
+            options.context.push('#/components/requestBodies/'+r);
+            validateComponentName(r).should.be.equal(true,'component name invalid');
+            if (r.startsWith('requestBody')) {
+                options.warnings.push('Anonymous requestBody: '+r);
+            }
+            let rb = openapi.components.requestBodies[r];
+            rb.should.have.property('content');
+            if (typeof rb.description !== 'undefined') should(rb.description).have.type('string');
+            if (typeof rb.required !== 'undefined') rb.required.should.have.type('boolean');
+            checkContent(rb.content,openapi.servers,openapi,options);
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (openapi.components && openapi.components.callbacks) {
-		options.context.push('#/components/callbacks');
-		openapi.components.callbacks.should.be.type('object');
-		openapi.components.callbacks.should.not.be.an.Array();
-		for (let c in openapi.components.callbacks) {
-			options.context.push('#/components/callbacks/'+c);
-			validateComponentName(c).should.be.equal(true,'component name invalid');
-			let cb = openapi.components.callbacks[c];
-			if (!cb.$ref) {
-				for (let u in cb) {
-					let cbPi = cb[u];
-					checkPathItem(cbPi,openapi,options);
-				}
-			}
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.callbacks) {
+        options.context.push('#/components/callbacks');
+        openapi.components.callbacks.should.be.type('object');
+        openapi.components.callbacks.should.not.be.an.Array();
+        for (let c in openapi.components.callbacks) {
+            options.context.push('#/components/callbacks/'+c);
+            validateComponentName(c).should.be.equal(true,'component name invalid');
+            let cb = openapi.components.callbacks[c];
+            if (!cb.$ref) {
+                for (let u in cb) {
+                    let cbPi = cb[u];
+                    checkPathItem(cbPi,openapi,options);
+                }
+            }
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
-	if (openapi.components && openapi.components.links) {
-		options.context.push('#/components/links');
-		openapi.components.links.should.be.type('object');
-		openapi.components.links.should.not.be.an.Array();
-		for (let l in openapi.components.links) {
-			options.context.push('#/components/links/'+l);
-			validateComponentName(l).should.be.equal(true,'component name invalid');
-			let link = openapi.components.links[l];
-			if (!link.$ref) {
-				checkLink(link,options);
-			}
-			options.context.pop();
-		}
-		options.context.pop();
-	}
+    if (openapi.components && openapi.components.links) {
+        options.context.push('#/components/links');
+        openapi.components.links.should.be.type('object');
+        openapi.components.links.should.not.be.an.Array();
+        for (let l in openapi.components.links) {
+            options.context.push('#/components/links/'+l);
+            validateComponentName(l).should.be.equal(true,'component name invalid');
+            let link = openapi.components.links[l];
+            if (!link.$ref) {
+                checkLink(link,options);
+            }
+            options.context.pop();
+        }
+        options.context.pop();
+    }
 
     validateOpenAPI3(openapi);
     var errors = validateOpenAPI3.errors;
     if (errors && errors.length) {
-		throw(new Error('Failed OpenAPI3 schema validation: '+JSON.stringify(errors,null,2)));
+        throw(new Error('Failed OpenAPI3 schema validation: '+JSON.stringify(errors,null,2)));
     }
 
-	options.valid = !options.expectFailure;
-	if (callback) callback(null,options);
+    options.valid = !options.expectFailure;
+    if (callback) callback(null,options);
     return options.valid;
 }
 
 function validate(openapi, options, callback) {
-	process.nextTick(function(){
-		validateSync(openapi, options, callback);
-	});
+    process.nextTick(function(){
+        validateSync(openapi, options, callback);
+    });
 }
 
 module.exports = {

--- a/validate.js
+++ b/validate.js
@@ -15,10 +15,10 @@ var ajv = require('ajv')({
     patternGroups: true,
     extendRefs: true // optional, current default is to 'fail', spec behaviour is to 'ignore'
 });
-    //meta: false, // optional, to prevent adding draft-06 meta-schema
+//meta: false, // optional, to prevent adding draft-06 meta-schema
 
 var ajvFormats = require('ajv/lib/compile/formats.js');
-ajv.addFormat('uriref',ajvFormats.full['uri-reference']);
+ajv.addFormat('uriref', ajvFormats.full['uri-reference']);
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
 ajv._refs['http://json-schema.org/schema'] = 'http://json-schema.org/draft-04/schema'; // optional, using unversioned URI is out of spec
 var metaSchema = require('ajv/lib/refs/json-schema-v5.json');
@@ -33,23 +33,23 @@ var validateMetaSchema = ajv.compile(jsonSchema);
 var openapi3Schema = require('./schemas/openapi-3.0.json');
 var validateOpenAPI3 = ajv.compile(openapi3Schema);
 
-function contextAppend(options,s) {
-    options.context.push((options.context[options.context.length-1]+'/'+s).split('//').join('/'));
+function contextAppend(options, s) {
+    options.context.push((options.context[options.context.length - 1] + '/' + s).split('//').join('/'));
 }
 
-function validateUrl(s,contextServers,context,options) {
-    if (!options.laxurls) s.should.not.be.exactly('','Invalid empty URL '+context);
-    var base = options.origin||'http://localhost/';
+function validateUrl(s, contextServers, context, options) {
+    if (!options.laxurls) s.should.not.be.exactly('', 'Invalid empty URL ' + context);
+    var base = options.origin || 'http://localhost/';
     if (contextServers && contextServers.length) {
         let servers = contextServers[0];
         if (servers.length) {
             base = servers[0].url;
         }
     }
-    if (s.indexOf('://')>0) { // FIXME HACK
+    if (s.indexOf('://') > 0) { // FIXME HACK
         base = undefined;
     }
-    var u = (URL && options.whatwg) ? new URL(s,base) : url.parse(s);
+    var u = (URL && options.whatwg) ? new URL(s, base) : url.parse(s);
     return true; // if we haven't thrown
 }
 
@@ -61,24 +61,24 @@ function validateHeaderName(name) {
     return /^[A-Za-z0-9!#\-\$%&'\*\+\\\.\^_`\|~]+$/.test(name);
 }
 
-function validateSchema(schema,openapi,options) {
+function validateSchema(schema, openapi, options) {
     validateMetaSchema(schema);
     var errors = validateSchema.errors;
     if (errors && errors.length) {
-        throw(new Error('Schema invalid: '+util.inspect(errors)));
+        throw (new Error('Schema invalid: ' + util.inspect(errors)));
     }
     if (schema.externalDocs) {
         schema.externalDocs.should.have.key('url');
         schema.externalDocs.url.should.have.type('string');
-        validateUrl(schema.externalDocs.url,[openapi.servers],'externalDocs',options).should.not.throw();
+        validateUrl(schema.externalDocs.url, [openapi.servers], 'externalDocs', options).should.not.throw();
     }
     return !(errors && errors.length);
 }
 
-function checkContent(content,contextServers,openapi,options) {
-    contextAppend(options,'content');
+function checkContent(content, contextServers, openapi, options) {
+    contextAppend(options, 'content');
     for (let ct in content) {
-        contextAppend(options,jptr.jpescape(ct));
+        contextAppend(options, jptr.jpescape(ct));
         var contentType = content[ct];
         should(contentType).be.an.Object();
         should(contentType).not.be.an.Array();
@@ -90,7 +90,7 @@ function checkContent(content,contextServers,openapi,options) {
             contentType.should.not.have.property('examples');
         }
         if (contentType.examples) {
-            contextAppend(options,'examples');
+            contextAppend(options, 'examples');
             contentType.should.not.have.property('example');
             contentType.examples.should.be.an.Object();
             contentType.examples.should.not.be.an.Array();
@@ -109,39 +109,39 @@ function checkContent(content,contextServers,openapi,options) {
                 if (typeof contentType.examples[ex].externalValue !== 'undefined') {
                     contentType.examples[ex].externalValue.should.have.type('string');
                     contentType.examples[ex].should.not.have.property('value');
-                    (function(){validateUrl(contentType.examples[ex].externalValue,contextServers,'examples..externalValue',options)}).should.not.throw();
+                    (function () { validateUrl(contentType.examples[ex].externalValue, contextServers, 'examples..externalValue', options) }).should.not.throw();
                 }
 
             }
             options.context.pop();
         }
-        if (contentType.schema) validateSchema(contentType.schema,openapi,options);
+        if (contentType.schema) validateSchema(contentType.schema, openapi, options);
         options.context.pop();
     }
     options.context.pop();
 }
 
-function checkServer(server,options) {
+function checkServer(server, options) {
     server.should.have.property('url');
-    (function(){validateUrl(server.url,[],'server.url',options)}).should.not.throw();
+    (function () { validateUrl(server.url, [], 'server.url', options) }).should.not.throw();
     let srvVars = 0;
-    server.url.replace(/\{(.+?)\}/g,function(match,group1) {
+    server.url.replace(/\{(.+?)\}/g, function (match, group1) {
         srvVars++;
         server.should.have.key('variables');
         server.variables.should.have.key(group1);
     });
     if (server.variables) {
-        contextAppend(options,'variables');
+        contextAppend(options, 'variables');
         for (let v in server.variables) {
-            contextAppend(options,v);
+            contextAppend(options, v);
             server.variables[v].should.have.key('default');
             server.variables[v].default.should.be.type('string');
             if (typeof server.variables[v].enum !== 'undefined') {
-                contextAppend(options,'enum');
+                contextAppend(options, 'enum');
                 server.variables[v].enum.should.be.an.Array();
-                should(server.variables[v].enum.length).not.be.exactly(0,'Server variables enum should not be empty');
+                should(server.variables[v].enum.length).not.be.exactly(0, 'Server variables enum should not be empty');
                 for (let e in server.variables[v].enum) {
-                    contextAppend(options,e);
+                    contextAppend(options, e);
                     server.variables[v].enum[e].should.be.type('string');
                     options.context.pop();
                 }
@@ -154,17 +154,17 @@ function checkServer(server,options) {
     }
 }
 
-function checkServers(servers,options) {
+function checkServers(servers, options) {
     servers.should.be.an.Array();
     for (let s in servers) {
-        contextAppend(options,s);
+        contextAppend(options, s);
         let server = servers[s];
-        checkServer(server,options);
+        checkServer(server, options);
         options.context.pop();
     }
 }
 
-function checkLink(link,options) {
+function checkLink(link, options) {
     link.should.be.type('object');
     if (typeof link.operationRef !== 'undefined') {
         link.operationRef.should.be.type('string');
@@ -183,16 +183,16 @@ function checkLink(link,options) {
         link.description.should.have.type('string');
     }
     if (typeof link.server !== 'undefined') {
-        checkServer(link.server,options);
+        checkServer(link.server, options);
     }
 }
 
-function checkHeader(header,contextServers,openapi,options) {
+function checkHeader(header, contextServers, openapi, options) {
     if (header.$ref) {
         var ref = header.$ref;
-        should(Object.keys(header).length).be.exactly(1,'Reference object cannot be extended');
-        header = common.resolveInternal(openapi,ref);
-        should(header).not.be.exactly(false,'Could not resolve reference '+ref);
+        should(Object.keys(header).length).be.exactly(1, 'Reference object cannot be extended');
+        header = common.resolveInternal(openapi, ref);
+        should(header).not.be.exactly(false, 'Could not resolve reference ' + ref);
     }
     header.should.not.have.property('name');
     header.should.not.have.property('in');
@@ -212,7 +212,7 @@ function checkHeader(header,contextServers,openapi,options) {
         if (typeof header.allowReserved !== 'undefined') {
             header.allowReserved.should.be.type('boolean');
         }
-        validateSchema(header.schema,openapi,options);
+        validateSchema(header.schema, openapi, options);
     }
     if (header.content) {
         header.should.not.have.property('schema');
@@ -221,69 +221,69 @@ function checkHeader(header,contextServers,openapi,options) {
         header.should.not.have.property('allowReserved');
         header.should.not.have.property('example');
         header.should.not.have.property('examples');
-        checkContent(header.content,contextServers,openapi,options);
+        checkContent(header.content, contextServers, openapi, options);
     }
     if (!header.schema && !header.content) {
-        header.should.have.property('schema','Header should have schema or content');
+        header.should.have.property('schema', 'Header should have schema or content');
     }
 }
 
-function checkResponse(response,contextServers,openapi,options) {
+function checkResponse(response, contextServers, openapi, options) {
     if (response.$ref) {
         var ref = response.$ref;
-        should(Object.keys(response).length).be.exactly(1,'Reference object cannot be extended');
-        response = common.resolveInternal(openapi,ref);
-        should(response).not.be.exactly(false,'Could not resolve reference '+ref);
+        should(Object.keys(response).length).be.exactly(1, 'Reference object cannot be extended');
+        response = common.resolveInternal(openapi, ref);
+        should(response).not.be.exactly(false, 'Could not resolve reference ' + ref);
     }
     response.should.have.property('description');
-    should(response.description).have.type('string','response description should be of type string');
+    should(response.description).have.type('string', 'response description should be of type string');
     response.should.not.have.property('examples');
     if (typeof response.schema !== 'undefined') {
         response.schema.should.be.an.Object();
         response.schema.should.not.be.an.Array();
     }
     if (response.headers) {
-        contextAppend(options,'headers');
+        contextAppend(options, 'headers');
         for (let h in response.headers) {
-            contextAppend(options,h);
-            validateHeaderName(h).should.be.equal(true,'Header doesn\'t match RFC7230 pattern');
-            checkHeader(response.headers[h],contextServers,openapi,options);
+            contextAppend(options, h);
+            validateHeaderName(h).should.be.equal(true, 'Header doesn\'t match RFC7230 pattern');
+            checkHeader(response.headers[h], contextServers, openapi, options);
             options.context.pop();
         }
         options.context.pop();
     }
 
     if (response.content) {
-        checkContent(response.content,contextServers,openapi,options);
+        checkContent(response.content, contextServers, openapi, options);
     }
 
     if (typeof response.links !== 'undefined') {
-        contextAppend(options,'links');
+        contextAppend(options, 'links');
         for (let l in response.links) {
-            contextAppend(options,l);
-            checkLink(response.links[l],options);
+            contextAppend(options, l);
+            checkLink(response.links[l], options);
             options.context.pop();
         }
         options.context.pop();
     }
 }
 
-function checkParam(param,index,contextServers,openapi,options){
-    contextAppend(options,index);
+function checkParam(param, index, contextServers, openapi, options) {
+    contextAppend(options, index);
     if (param.$ref) {
-        should(Object.keys(param).length).be.exactly(1,'Reference object cannot be extended');
+        should(Object.keys(param).length).be.exactly(1, 'Reference object cannot be extended');
         var ref = param.$ref;
-        param = common.resolveInternal(openapi,ref);
-        should(param).not.be.exactly(false,'Could not resolve reference '+ref);
+        param = common.resolveInternal(openapi, ref);
+        should(param).not.be.exactly(false, 'Could not resolve reference ' + ref);
     }
     param.should.have.property('name');
     param.name.should.have.type('string');
     param.should.have.property('in');
     param.in.should.have.type('string');
-    param.in.should.equalOneOf('query','header','path','cookie');
+    param.in.should.equalOneOf('query', 'header', 'path', 'cookie');
     if (param.in == 'path') {
         param.should.have.property('required');
-        param.required.should.be.exactly(true,'Path parameters must have an explicit required:true');
+        param.required.should.be.exactly(true, 'Path parameters must have an explicit required:true');
     }
     if (typeof param.required !== 'undefined') should(param.required).have.type('boolean');
     param.should.not.have.property('items');
@@ -292,8 +292,8 @@ function checkParam(param,index,contextServers,openapi,options){
     for (let prop of common.parameterTypeProperties) {
         param.should.not.have.property(prop);
     }
-    param.in.should.not.be.exactly('body','Parameter type body is no-longer valid');
-    param.in.should.not.be.exactly('formData','Parameter type formData is no-longer valid');
+    param.in.should.not.be.exactly('body', 'Parameter type body is no-longer valid');
+    param.in.should.not.be.exactly('formData', 'Parameter type formData is no-longer valid');
     if (param.description) {
         param.description.should.have.type('string');
     }
@@ -325,7 +325,7 @@ function checkParam(param,index,contextServers,openapi,options){
         if (typeof param.allowReserved !== 'undefined') {
             param.allowReserved.should.be.type('boolean');
         }
-        validateSchema(param.schema,openapi,options);
+        validateSchema(param.schema, openapi, options);
     }
     if (param.content) {
         param.should.not.have.property('schema');
@@ -334,33 +334,33 @@ function checkParam(param,index,contextServers,openapi,options){
         param.should.not.have.property('allowReserved');
         param.should.not.have.property('example');
         param.should.not.have.property('examples');
-        should(Object.keys(param.content).length).be.exactly(1,'Parameter content must have only one entry');
-        checkContent(param.content,contextServers,openapi,options);
+        should(Object.keys(param.content).length).be.exactly(1, 'Parameter content must have only one entry');
+        checkContent(param.content, contextServers, openapi, options);
     }
     if (!param.schema && !param.content) {
-        param.should.have.property('schema','Parameter should have schema or content');
+        param.should.have.property('schema', 'Parameter should have schema or content');
     }
     options.context.pop();
     return true;
 }
 
-function checkPathItem(pathItem,openapi,options) {
+function checkPathItem(pathItem, openapi, options) {
 
     var contextServers = [];
     contextServers.push(openapi.servers);
     if (pathItem.servers) contextServers.push(pathItem.servers);
 
     for (let o in pathItem) {
-        contextAppend(options,o);
+        contextAppend(options, o);
         var op = pathItem[o];
         if (o == 'parameters') {
             for (let p in pathItem.parameters) {
-                checkParam(pathItem.parameters[p],p,contextServers,openapi,options);
+                checkParam(pathItem.parameters[p], p, contextServers, openapi, options);
             }
         }
         else if (o == 'servers') {
-            contextAppend(options,'servers');
-            checkServers(op,options); // won't be here in converted definitions
+            contextAppend(options, 'servers');
+            checkServers(op, options); // won't be here in converted definitions
             options.context.pop();
         }
         else if (o == 'summary') {
@@ -369,7 +369,7 @@ function checkPathItem(pathItem,openapi,options) {
         else if (o == 'description') {
             pathItem.description.should.have.type('string');
         }
-        else if (common.httpVerbs.indexOf(o)>=0) {
+        else if (common.httpVerbs.indexOf(o) >= 0) {
             op.should.not.be.empty();
             op.should.not.have.property('consumes');
             op.should.not.have.property('produces');
@@ -380,53 +380,53 @@ function checkPathItem(pathItem,openapi,options) {
             if (op.description) op.description.should.have.type('string');
 
             if (op.servers) {
-                contextAppend(options,'servers');
-                checkServers(op.servers,options); // won't be here in converted definitions
+                contextAppend(options, 'servers');
+                checkServers(op.servers, options); // won't be here in converted definitions
                 options.context.pop();
                 contextServers.push(op.servers);
             }
 
             if (op.requestBody && op.requestBody.content) {
-                contextAppend(options,'requestBody');
+                contextAppend(options, 'requestBody');
                 op.requestBody.should.have.property('content');
                 if (typeof op.requestBody.description !== 'undefined') should(op.requestBody.description).have.type('string');
                 if (typeof op.requestBody.required !== 'undefined') op.requestBody.required.should.have.type('boolean');
-                checkContent(op.requestBody.content,contextServers,openapi,options);
+                checkContent(op.requestBody.content, contextServers, openapi, options);
                 options.context.pop();
             }
 
-            contextAppend(options,'responses');
+            contextAppend(options, 'responses');
             for (let r in op.responses) {
-                contextAppend(options,r);
+                contextAppend(options, r);
                 var response = op.responses[r];
-                checkResponse(response,contextServers,openapi,options);
+                checkResponse(response, contextServers, openapi, options);
                 options.context.pop();
             }
             options.context.pop();
 
             if (op.parameters) {
-                contextAppend(options,'parameters');
+                contextAppend(options, 'parameters');
                 for (let p in op.parameters) {
-                    checkParam(op.parameters[p],p,contextServers,openapi,options);
+                    checkParam(op.parameters[p], p, contextServers, openapi, options);
                 }
                 options.context.pop();
             }
             if (op.externalDocs) {
-                contextAppend(options,'externalDocs');
+                contextAppend(options, 'externalDocs');
                 op.externalDocs.should.have.key('url');
                 op.externalDocs.url.should.have.type('string');
-                (function(){validateUrl(op.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
+                (function () { validateUrl(op.externalDocs.url, contextServers, 'externalDocs', options) }).should.not.throw();
                 options.context.pop();
             }
             if (op.callbacks) {
-                contextAppend(options,'callbacks');
+                contextAppend(options, 'callbacks');
                 for (let c in op.callbacks) {
                     let callback = op.callbacks[c];
                     if (!callback.$ref) {
-                        contextAppend(options,c);
+                        contextAppend(options, c);
                         for (let p in callback) {
                             let cbPi = callback[p];
-                            checkPathItem(cbPi,openapi,options);
+                            checkPathItem(cbPi, openapi, options);
                         }
                         options.context.pop();
                     }
@@ -445,8 +445,8 @@ function validateSync(openapi, options, callback) {
     options.warnings = [];
 
     if (options.jsonschema) {
-        let schemaStr = fs.readFileSync(options.jsonschema,'utf8');
-        openapi3Schema = yaml.safeLoad(schemaStr,{json:true});
+        let schemaStr = fs.readFileSync(options.jsonschema, 'utf8');
+        openapi3Schema = yaml.safeLoad(schemaStr, { json: true });
         validateOpenAPI3 = ajv.compile(openapi3Schema);
     }
 
@@ -454,7 +454,7 @@ function validateSync(openapi, options, callback) {
     openapi.should.not.have.key('swagger');
     openapi.should.have.key('openapi');
     openapi.openapi.should.have.type('string');
-    should.ok(openapi.openapi.startsWith('3.0.'),'Must be an OpenAPI 3.0.x document');
+    should.ok(openapi.openapi.startsWith('3.0.'), 'Must be an OpenAPI 3.0.x document');
     openapi.should.not.have.key('host');
     openapi.should.not.have.key('basePath');
     openapi.should.not.have.key('schemes');
@@ -467,47 +467,47 @@ function validateSync(openapi, options, callback) {
     openapi.should.not.have.key('consumes');
 
     openapi.should.have.key('info');
-    contextAppend(options,'info');
+    contextAppend(options, 'info');
     openapi.info.should.have.key('title');
-    should(openapi.info.title).be.type('string','title should be of type string');
+    should(openapi.info.title).be.type('string', 'title should be of type string');
     openapi.info.should.have.key('version');
-    should(openapi.info.version).be.type('string','version should be of type string');
+    should(openapi.info.version).be.type('string', 'version should be of type string');
     if (openapi.info.license) {
-        contextAppend(options,'license');
+        contextAppend(options, 'license');
         openapi.info.license.should.have.key('name');
         openapi.info.license.name.should.have.type('string');
         options.context.pop();
     }
     if (typeof openapi.info.termsOfService !== 'undefined') {
         should(openapi.info.termsOfService).not.be.Null();
-        (function(){validateUrl(openapi.info.termsOfService,contextServers,'termsOfService',options)}).should.not.throw();
+        (function () { validateUrl(openapi.info.termsOfService, contextServers, 'termsOfService', options) }).should.not.throw();
     }
     options.context.pop();
 
     var contextServers = [];
     if (openapi.servers) {
-        contextAppend(options,'servers');
-        checkServers(openapi.servers,options);
+        contextAppend(options, 'servers');
+        checkServers(openapi.servers, options);
         options.context.pop();
         contextServers.push(openapi.servers);
     }
     if (openapi.externalDocs) {
-        contextAppend(options,'externalDocs');
+        contextAppend(options, 'externalDocs');
         openapi.externalDocs.should.have.key('url');
         openapi.externalDocs.url.should.have.type('string');
-        (function(){validateUrl(openapi.externalDocs.url,contextServers,'externalDocs',options)}).should.not.throw();
+        (function () { validateUrl(openapi.externalDocs.url, contextServers, 'externalDocs', options) }).should.not.throw();
         options.context.pop();
     }
 
     if (openapi.tags) {
-        contextAppend(options,'tags');
+        contextAppend(options, 'tags');
         for (let tag of openapi.tags) {
             tag.should.have.property('name');
             tag.name.should.have.type('string');
             if (tag.externalDocs) {
                 tag.externalDocs.should.have.key('url');
                 tag.externalDocs.url.should.have.type('string');
-                (function(){validateUrl(tag.externalDocs.url,contextServers,'tag.externalDocs',options)}).should.not.throw();
+                (function () { validateUrl(tag.externalDocs.url, contextServers, 'tag.externalDocs', options) }).should.not.throw();
             }
         }
         options.context.pop();
@@ -515,13 +515,13 @@ function validateSync(openapi, options, callback) {
 
     if (openapi.components && openapi.components.securitySchemes) {
         for (let s in openapi.components.securitySchemes) {
-            options.context.push('#/components/securitySchemes/'+s);
-            validateComponentName(s).should.be.equal(true,'component name invalid');
+            options.context.push('#/components/securitySchemes/' + s);
+            validateComponentName(s).should.be.equal(true, 'component name invalid');
             var scheme = openapi.components.securitySchemes[s];
             scheme.should.have.property('type');
             scheme.type.should.have.type('string');
-            scheme.type.should.not.be.exactly('basic','Security scheme basic should be http with scheme basic');
-            scheme.type.should.equalOneOf('apiKey','http','oauth2','openIdConnect');
+            scheme.type.should.not.be.exactly('basic', 'Security scheme basic should be http with scheme basic');
+            scheme.type.should.equalOneOf('apiKey', 'http', 'oauth2', 'openIdConnect');
             if (scheme.type == 'http') {
                 scheme.should.have.property('scheme');
                 scheme.scheme.should.have.type('string');
@@ -538,7 +538,7 @@ function validateSync(openapi, options, callback) {
                 scheme.name.should.have.type('string');
                 scheme.should.have.property('in');
                 scheme.in.should.have.type('string');
-                scheme.in.should.equalOneOf('query','header');
+                scheme.in.should.equalOneOf('query', 'header');
             }
             else {
                 scheme.should.not.have.property('name');
@@ -552,7 +552,7 @@ function validateSync(openapi, options, callback) {
                     if ((f == 'implicit') || (f == 'authorizationCode')) {
                         flow.should.have.property('authorizationUrl');
                         flow.authorizationUrl.should.have.type('string');
-                        (function(){validateUrl(flow.authorizationUrl,contextServers,'authorizationUrl',options)}).should.not.throw();
+                        (function () { validateUrl(flow.authorizationUrl, contextServers, 'authorizationUrl', options) }).should.not.throw();
                     }
                     else {
                         flow.should.not.have.property('authorizationUrl');
@@ -561,13 +561,13 @@ function validateSync(openapi, options, callback) {
                         (f == 'authorizationCode')) {
                         flow.should.have.property('tokenUrl');
                         flow.tokenUrl.should.have.type('string');
-                        (function(){validateUrl(flow.tokenUrl,contextServers,'tokenUrl',options)}).should.not.throw();
+                        (function () { validateUrl(flow.tokenUrl, contextServers, 'tokenUrl', options) }).should.not.throw();
                     }
                     else {
                         flow.should.not.have.property('tokenUrl');
                     }
                     if (typeof flow.refreshUrl !== 'undefined') {
-                        (function(){validateUrl(flow.refreshUrl,contextServers,'refreshUrl',options)}).should.not.throw();
+                        (function () { validateUrl(flow.refreshUrl, contextServers, 'refreshUrl', options) }).should.not.throw();
                     }
                     flow.should.have.property('scopes');
                 }
@@ -578,7 +578,7 @@ function validateSync(openapi, options, callback) {
             if (scheme.type == 'openIdConnect') {
                 scheme.should.have.property('openIdConnectUrl');
                 scheme.openIdConnectUrl.should.have.type('string');
-                (function(){validateUrl(scheme.openIdConnectUrl,contextServers,'openIdConnectUrl',options)}).should.not.throw();
+                (function () { validateUrl(scheme.openIdConnectUrl, contextServers, 'openIdConnectUrl', options) }).should.not.throw();
             }
             else {
                 scheme.should.not.have.property('openIdConnectUrl');
@@ -587,32 +587,32 @@ function validateSync(openapi, options, callback) {
         }
     }
 
-    common.recurse(openapi,null,function(obj,key,state){
+    common.recurse(openapi, null, function (obj, key, state) {
         if ((key === '$ref') && (typeof obj[key] === 'string')) {
             options.context.push(state.path);
             obj[key].should.not.startWith('#/definitions/');
-            should(Object.keys(obj).length).be.exactly(1,'Reference object cannot be extended');
+            should(Object.keys(obj).length).be.exactly(1, 'Reference object cannot be extended');
             var refUrl = url.parse(obj[key]);
             if (!refUrl.protocol && !refUrl.path) {
-                should(jptr.jptr(openapi,obj[key])).not.be.exactly(false,'Cannot resolve reference: '+obj[key]);
+                should(jptr.jptr(openapi, obj[key])).not.be.exactly(false, 'Cannot resolve reference: ' + obj[key]);
             }
             options.context.pop();
         }
     });
 
     for (let p in openapi.paths) {
-        options.context.push('#/paths/'+jptr.jpescape(p));
+        options.context.push('#/paths/' + jptr.jpescape(p));
         if (!p.startsWith('x-')) {
             p.should.startWith('/');
-            checkPathItem(openapi.paths[p],openapi,options);
+            checkPathItem(openapi.paths[p], openapi, options);
         }
         options.context.pop();
     }
     if (openapi["x-ms-paths"]) {
         for (let p in openapi["x-ms-paths"]) {
-            options.context.push('#/x-ms-paths/'+jptr.jpescape(p));
+            options.context.push('#/x-ms-paths/' + jptr.jpescape(p));
             p.should.startWith('/');
-            checkPathItem(openapi["x-ms-paths"][p],openapi,options);
+            checkPathItem(openapi["x-ms-paths"][p], openapi, options);
             options.context.pop();
         }
     }
@@ -620,9 +620,9 @@ function validateSync(openapi, options, callback) {
     if (openapi.components && openapi.components.parameters) {
         options.context.push('#/components/parameters/');
         for (let p in openapi.components.parameters) {
-            checkParam(openapi.components.parameters[p],p,contextServers,openapi,options);
+            checkParam(openapi.components.parameters[p], p, contextServers, openapi, options);
             contextAppend(options, p);
-            validateComponentName(p).should.be.equal(true,'component name invalid');
+            validateComponentName(p).should.be.equal(true, 'component name invalid');
             options.context.pop();
         }
         options.context.pop();
@@ -633,9 +633,9 @@ function validateSync(openapi, options, callback) {
         openapi.components.schemas.should.be.type('object');
         openapi.components.schemas.should.not.be.an.Array();
         for (let s in openapi.components.schemas) {
-            options.context.push('#/components/schemas/'+s);
-            validateComponentName(s).should.be.equal(true,'component name invalid');
-            validateSchema(openapi.components.schemas[s],openapi,options);
+            options.context.push('#/components/schemas/' + s);
+            validateComponentName(s).should.be.equal(true, 'component name invalid');
+            validateSchema(openapi.components.schemas[s], openapi, options);
             options.context.pop();
         }
         options.context.pop();
@@ -646,9 +646,9 @@ function validateSync(openapi, options, callback) {
         openapi.components.responses.should.be.type('object');
         openapi.components.responses.should.not.be.an.Array();
         for (let r in openapi.components.responses) {
-            options.context.push('#/components/responses/'+r);
-            validateComponentName(r).should.be.equal(true,'component name invalid');
-            checkResponse(openapi.components.responses[r],contextServers,openapi,options);
+            options.context.push('#/components/responses/' + r);
+            validateComponentName(r).should.be.equal(true, 'component name invalid');
+            checkResponse(openapi.components.responses[r], contextServers, openapi, options);
             options.context.pop();
         }
         options.context.pop();
@@ -659,9 +659,9 @@ function validateSync(openapi, options, callback) {
         openapi.components.headers.should.be.type('object');
         openapi.components.headers.should.not.be.an.Array();
         for (let h in openapi.components.headers) {
-            options.context.push('#/components/headers/'+h);
-            validateComponentName(h).should.be.equal(true,'component name invalid');
-            checkHeader(openapi.components.headers[h],contextServers,openapi,options);
+            options.context.push('#/components/headers/' + h);
+            validateComponentName(h).should.be.equal(true, 'component name invalid');
+            checkHeader(openapi.components.headers[h], contextServers, openapi, options);
             options.context.pop();
         }
         options.context.pop();
@@ -672,16 +672,16 @@ function validateSync(openapi, options, callback) {
         openapi.components.requestBodies.should.be.type('object');
         openapi.components.requestBodies.should.not.be.an.Array();
         for (let r in openapi.components.requestBodies) {
-            options.context.push('#/components/requestBodies/'+r);
-            validateComponentName(r).should.be.equal(true,'component name invalid');
+            options.context.push('#/components/requestBodies/' + r);
+            validateComponentName(r).should.be.equal(true, 'component name invalid');
             if (r.startsWith('requestBody')) {
-                options.warnings.push('Anonymous requestBody: '+r);
+                options.warnings.push('Anonymous requestBody: ' + r);
             }
             let rb = openapi.components.requestBodies[r];
             rb.should.have.property('content');
             if (typeof rb.description !== 'undefined') should(rb.description).have.type('string');
             if (typeof rb.required !== 'undefined') rb.required.should.have.type('boolean');
-            checkContent(rb.content,openapi.servers,openapi,options);
+            checkContent(rb.content, openapi.servers, openapi, options);
             options.context.pop();
         }
         options.context.pop();
@@ -692,13 +692,13 @@ function validateSync(openapi, options, callback) {
         openapi.components.callbacks.should.be.type('object');
         openapi.components.callbacks.should.not.be.an.Array();
         for (let c in openapi.components.callbacks) {
-            options.context.push('#/components/callbacks/'+c);
-            validateComponentName(c).should.be.equal(true,'component name invalid');
+            options.context.push('#/components/callbacks/' + c);
+            validateComponentName(c).should.be.equal(true, 'component name invalid');
             let cb = openapi.components.callbacks[c];
             if (!cb.$ref) {
                 for (let u in cb) {
                     let cbPi = cb[u];
-                    checkPathItem(cbPi,openapi,options);
+                    checkPathItem(cbPi, openapi, options);
                 }
             }
             options.context.pop();
@@ -711,11 +711,11 @@ function validateSync(openapi, options, callback) {
         openapi.components.links.should.be.type('object');
         openapi.components.links.should.not.be.an.Array();
         for (let l in openapi.components.links) {
-            options.context.push('#/components/links/'+l);
-            validateComponentName(l).should.be.equal(true,'component name invalid');
+            options.context.push('#/components/links/' + l);
+            validateComponentName(l).should.be.equal(true, 'component name invalid');
             let link = openapi.components.links[l];
             if (!link.$ref) {
-                checkLink(link,options);
+                checkLink(link, options);
             }
             options.context.pop();
         }
@@ -725,21 +725,21 @@ function validateSync(openapi, options, callback) {
     validateOpenAPI3(openapi);
     var errors = validateOpenAPI3.errors;
     if (errors && errors.length) {
-        throw(new Error('Failed OpenAPI3 schema validation: '+JSON.stringify(errors,null,2)));
+        throw (new Error('Failed OpenAPI3 schema validation: ' + JSON.stringify(errors, null, 2)));
     }
 
     options.valid = !options.expectFailure;
-    if (callback) callback(null,options);
+    if (callback) callback(null, options);
     return options.valid;
 }
 
 function validate(openapi, options, callback) {
-    process.nextTick(function(){
+    process.nextTick(function () {
         validateSync(openapi, options, callback);
     });
 }
 
 module.exports = {
-    validateSync : validateSync,
-    validate : validate
+    validateSync: validateSync,
+    validate: validate
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,31 +2,31 @@
 var webpack = require('webpack');
 
 var commonsPlugin =
-  new webpack.optimize.CommonsChunkPlugin('common');
+    new webpack.optimize.CommonsChunkPlugin('common');
 
 module.exports = {
-  node: {
-    fs: "empty"
-  },
-  entry: {
-    Converter: './index.js',
-    Validator: './validate.js'
-  },
-  output: {
-    filename: 'dist/[name].js', // Template based on keys in entry above
-    library: '[name]', // was constant
-    libraryTarget: 'var'
-  },
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['babel-preset-es2015'].map(require.resolve)
-        }
-      }
-    ]
-  },
-  plugins: [commonsPlugin]
+    node: {
+        fs: "empty"
+    },
+    entry: {
+        Converter: './index.js',
+        Validator: './validate.js'
+    },
+    output: {
+        filename: 'dist/[name].js', // Template based on keys in entry above
+        library: '[name]', // was constant
+        libraryTarget: 'var'
+    },
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                loader: 'babel-loader',
+                query: {
+                    presets: ['babel-preset-es2015'].map(require.resolve)
+                }
+            }
+        ]
+    },
+    plugins: [commonsPlugin]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,16 +6,16 @@ var commonsPlugin =
 
 module.exports = {
   node: {
-	fs: "empty"
+    fs: "empty"
   },
   entry: {
-	Converter: './index.js',
-	Validator: './validate.js'
+    Converter: './index.js',
+    Validator: './validate.js'
   },
   output: {
     filename: 'dist/[name].js', // Template based on keys in entry above
-	library: '[name]', // was constant
-	libraryTarget: 'var'
+    library: '[name]', // was constant
+    libraryTarget: 'var'
   },
   module: {
     loaders: [


### PR DESCRIPTION
Feel free to totally ignore this one, but I was debugging some code recently and the mix of tabs and spaces and indentation styles was doing my head in.

I've added an [editorconfig](http://editorconfig.org/) file, and converted all `.js/.json` files to use spaces, with a 4 space indentation.

VSCode cleaned up a couple of additional stylistic things (like adding extra spaces around brackets and stuff). I didn't intend on doing that, but looks like we got it for free?

Oh, to make things a bit easier to view, don't forget about Github's ["hide whitespace"](https://github.com/Mermade/swagger2openapi/pull/14/files?w=1) trick 👍 