### PR TITLE
convert x-example within parameter to example

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,5 +15,6 @@ x-required|[swaggerplusplus](https://github.com/mermade/swaggerplusplus)|Within 
 x-deprecated|[swaggerplusplus](https://github.com/mermade/swaggerplusplus)|Within parameters, converted to `deprecated`
 x-links|[swaggerplusplus](https://github.com/mermade/swaggerplusplus)|At root and within responses, converted to `links`/`components/links`
 x-callbacks|[swaggerplusplus](https://github.com/mermade/swaggerplusplus)|At root and within operations, converted to `callbacks`/`components/callbacks`
+x-example|[apiary](https://help.apiary.io/api_101/swagger-extensions/#x-example)|Within parameters, converted to `example`
 
 See also [APIMatic extensions](https://docs.apimatic.io/advanced/swagger-server-configuration-extensions/)

--- a/index.js
+++ b/index.js
@@ -297,6 +297,11 @@ function processParameter(param, op, path, index, openapi, options) {
             delete param['x-deprecated'];
         }
 
+        if (typeof param['x-example'] !== 'undefined') {
+            param.example = param['x-example'];
+            delete param['x-example'];
+        }
+
         if ((param.in != 'body') && (!param.type)) {
             if (options.patch) {
                 param.type = 'string';


### PR DESCRIPTION
Hey @MikeRalphson,

great job with this project! 🔥 
I'm going to use it in the upcoming ReDoc major release which will be based on OpenAPI3 to support 2.0 specs.

This PR adds support for `x-example` vendor extension which is used by some ReDoc users. The vendor of this extension is Apiary: https://help.apiary.io/api_101/swagger-extensions/#x-example