### PR TITLE
Use simpler hash function to avoid huge polyfill with webpack

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const crypto = require('crypto');
 const fs = require('fs');
 const url = require('url');
 
@@ -19,10 +18,21 @@ function hasDuplicates(array) {
     return (new Set(array)).size !== array.length;
 }
 
-function sha256(s) {
-    var shasum = crypto.createHash('sha256');
-    shasum.update(s);
-    return shasum.digest('hex');
+/**
+ * simple hash implementation based on https://stackoverflow.com/a/7616484/1749888
+ * @param {string} s - string to hash
+ * @returns {number} numerical hash code
+ */
+function hash(s) {
+    let hash = 0;
+    let chr;
+    if (s.length === 0) return hash;
+    for (let i = 0; i < s.length; i++) {
+      chr   = s.charCodeAt(i);
+      hash  = ((hash << 5) - hash) + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
 }
 
 String.prototype.toCamelCase = function camelize() {
@@ -179,7 +189,7 @@ module.exports = {
     uniqueOnly: uniqueOnly,
     hasDuplicates: hasDuplicates,
     recurse: recurse,
-    sha256: sha256,
+    hash: hash,
     getVersion: getVersion,
     resolveExternal: resolveExternal,
     resolveInternal: jptr,

--- a/index.js
+++ b/index.js
@@ -812,16 +812,16 @@ function processPaths(container, containerName, options, requestBodyCache, opena
                     var rbName = common.sanitise(op.requestBody['x-s2o-name'] || effectiveOperationId || '');
                     delete op.requestBody['x-s2o-name'];
                     var rbStr = JSON.stringify(op.requestBody);
-                    var rbSha256 = common.sha256(rbStr);
-                    if (!requestBodyCache[rbSha256]) {
+                    var rbHash = common.hash(rbStr);
+                    if (!requestBodyCache[rbHash]) {
                         var entry = {};
                         entry.name = rbName;
                         entry.body = op.requestBody;
                         entry.refs = [];
-                        requestBodyCache[rbSha256] = entry;
+                        requestBodyCache[rbHash] = entry;
                     }
                     let ptr = '#/'+containerName+'/'+encodeURIComponent(jptr.jpescape(p))+'/'+method+'/requestBody';
-                    requestBodyCache[rbSha256].refs.push(ptr);
+                    requestBodyCache[rbHash].refs.push(ptr);
                 }
 
             }
@@ -919,12 +919,12 @@ function main(openapi, options) {
     for (let r in openapi.components.requestBodies) { // converted ones
         let rb = openapi.components.requestBodies[r];
         let rbStr = JSON.stringify(rb);
-        let rbSha256 = common.sha256(rbStr);
+        let rbHash = common.hash(rbStr);
         let entry = {};
         entry.name = r;
         entry.body = rb;
         entry.refs = [];
-        requestBodyCache[rbSha256] = entry;
+        requestBodyCache[rbHash] = entry;
     }
 
     processPaths(openapi.paths, 'paths', options, requestBodyCache, openapi);


### PR DESCRIPTION
it saves around 280kB of minified code when using in ReDoc with webpack:

before:
```
...
Version: webpack 3.8.1
Time: 27183ms
              Asset       Size  Chunks                    Chunk Names
    redoc.bundle.js    1.06 MB       0  [emitted]  [big]  main
....
```


after:
```
...
Version: webpack 3.8.1
Time: 21973ms
              Asset       Size  Chunks                    Chunk Names
    redoc.bundle.js     780 kB       0  [emitted]  [big]  main
...
```
