### PR TITLE
fix: `checkResponse` will now check schema of response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ in/
 out/
 dev/
 t/
+.idea/
 
 test/_*/
 

--- a/validate.js
+++ b/validate.js
@@ -498,7 +498,7 @@ function checkResponse(response, contextServers, openapi, options) {
     if (typeof response.schema !== 'undefined') {
         response.schema.should.be.an.Object();
         response.schema.should.not.be.an.Array();
-        checkSchema(contentType.schema,{},'schema',openapi,options);
+        checkSchema(response.schema,{},'schema',openapi,options);
     }
     if (response.headers) {
         contextAppend(options, 'headers');


### PR DESCRIPTION
This fixes https://github.com/Mermade/swagger2openapi/issues/56